### PR TITLE
Fix PDF/print ordering and remove extra column indentation

### DIFF
--- a/cv.html
+++ b/cv.html
@@ -198,6 +198,7 @@
         display: grid;
         grid-template-columns: 1.8fr 1fr;
         gap: 12mm;
+        margin-top: 12mm;
       }
       .pdf-section { margin-bottom: 22px; break-inside: avoid; }
       .pdf-entry { margin-bottom: 16px; break-inside: avoid; }
@@ -256,13 +257,19 @@
       }
       function sortItems(items) {
         return [...items].sort((a, b) => {
+          const aManual = String(a.manualsort || "").trim();
+          const bManual = String(b.manualsort || "").trim();
+          if (aManual && bManual && aManual !== bManual) {
+            return aManual.localeCompare(bManual, undefined, { numeric: true, sensitivity: "base" });
+          }
+          if (aManual && !bManual) return -1;
+          if (!aManual && bManual) return 1;
+
           const byStart = parseDateValue(b.start) - parseDateValue(a.start);
           if (byStart !== 0) return byStart;
           const byEnd = parseDateValue(b.end) - parseDateValue(a.end);
           if (byEnd !== 0) return byEnd;
-          const aManual = Number.isFinite(Number(a.manualsort)) ? Number(a.manualsort) : Number.MAX_SAFE_INTEGER;
-          const bManual = Number.isFinite(Number(b.manualsort)) ? Number(b.manualsort) : Number.MAX_SAFE_INTEGER;
-          return aManual - bManual;
+          return 0;
         });
       }
       function titleCase(value) {
@@ -529,7 +536,7 @@
         buildPdfHeader(page1, headerItem, contacts);
 
         const grid1 = document.createElement("section");
-        grid1.className = "pdf-grid content";
+        grid1.className = "pdf-grid";
         const main1 = document.createElement("div");
         const rail1 = document.createElement("aside");
         grid1.append(main1, rail1);
@@ -555,7 +562,7 @@
         const page2 = document.createElement("div");
         page2.className = "pdf-page";
         const grid2 = document.createElement("section");
-        grid2.className = "pdf-grid content";
+        grid2.className = "pdf-grid";
         const main2 = document.createElement("div");
         const rail2 = document.createElement("aside");
         grid2.append(main2, rail2);
@@ -627,7 +634,7 @@
 
         for (let i = 0; i < pages.length; i += 1) {
           const canvas = await html2canvas(pages[i], {
-            scale: 2,
+            scale: 1,
             backgroundColor: "#ffffff",
             useCORS: true
           });


### PR DESCRIPTION
### Motivation
- Ensure work experience and other manually-ordered sections render in the original designated sequence in web, print, and PDF output.  
- Prevent printed/PDF pages from being scaled and stop the two-column PDF rail from being indented farther than the page margins.  

### Description
- Change `sortItems` to honor `manualsort` values first (string comparison with numeric sensitivity) and fall back to date-based ordering when `manualsort` is not present.  
- Remove the extra `content` class usage for PDF grids and add `margin-top` to `.pdf-grid` so the two-column PDF blocks line up with the page margins.  
- Set `html2canvas` `scale` to `1` (was `2`) to avoid upscaling content when rendering pages into images for the PDF.  
- Preserve existing per-entry `break-inside: avoid` behavior so individual work items do not break across page fragments.  

### Testing
- Ran `git diff --check` to ensure no formatting issues and the tree was clean.  
- Served the site with `python3 -m http.server 4173` and validated the live page at `/cv.html?cv=coleman-davis`.  
- Captured a print-media screenshot using Playwright (emulated `print`) and verified the PDF layout visually via the generated `artifacts/cv-print-layout.png` image.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad8a4d9ddc83228905e578e98c91cd)