### PR TITLE
fix: stabilize CV print preview and static PDF layout parity

### DIFF
--- a/cv-print.css
+++ b/cv-print.css
@@ -89,22 +89,16 @@ body {
 .content {
   margin-top: 6mm;
   width: 100%;
-}
-
-.content::after {
-  content: "";
-  display: block;
-  clear: both;
+  display: grid;
+  grid-template-columns: minmax(0, 1.95fr) minmax(0, 1fr);
+  column-gap: 6mm;
+  align-items: start;
 }
 
 .main-col,
 .rail-col {
   min-width: 0;
-  float: left;
 }
-
-.main-col { grid-column: 1; }
-.rail-col { grid-column: 2; }
 
 .section {
   margin-bottom: 10px;
@@ -182,11 +176,6 @@ aside#rail-col > section.section {
 .rail-col .entry-meta,
 .rail-col .entry-date,
 .rail-col .entry-content { font-size: 12px; }
-
-.rail-break-before {
-  break-before: page;
-  page-break-before: always;
-}
 
 
 .print-actions {

--- a/cv-print.html
+++ b/cv-print.html
@@ -16,8 +16,8 @@
       <header class="header" id="header"></header>
       <section class="contact-bar" id="contact"></section>
       <section class="content">
-        <aside class="rail-col" id="rail-col"></aside>
         <div class="main-col" id="main-col"></div>
+        <aside class="rail-col" id="rail-col"></aside>
       </section>
     </main>
 
@@ -28,41 +28,6 @@
       const pathSlug = (location.pathname.match(/cv-print-([a-z0-9-_]+)\.html$/i)?.[1] || "").trim().toLowerCase();
       const injectedSlug = String(window.__CV_SLUG__ || "").trim().toLowerCase();
       const slug = (query.get("cv") || injectedSlug || pathSlug || location.hash.replace(/^#/, "") || "coleman-davis").trim().toLowerCase();
-
-
-      function mmToPx(mm) {
-        const probe = document.createElement("div");
-        probe.style.width = `${mm}mm`;
-        probe.style.position = "absolute";
-        probe.style.visibility = "hidden";
-        document.body.appendChild(probe);
-        const px = probe.getBoundingClientRect().width;
-        probe.remove();
-        return px;
-      }
-
-      function applyRailEducationBreakIfSkillsFit() {
-        const railHost = document.getElementById("rail-col");
-        if (!railHost) return;
-
-        const sections = [...railHost.querySelectorAll(':scope > .section')];
-        const skillsSection = sections.find((section) => section.querySelector('h3')?.textContent?.trim().toLowerCase() === 'skills');
-        const educationSection = sections.find((section) => section.querySelector('h3')?.textContent?.trim().toLowerCase() === 'education');
-
-        if (!skillsSection || !educationSection) return;
-
-        const firstPageHeightPx = mmToPx(297);
-        const pageMarginPx = mmToPx(12);
-        const usablePageHeightPx = firstPageHeightPx - (pageMarginPx * 2);
-
-        const railTop = railHost.getBoundingClientRect().top;
-        const skillsBottom = skillsSection.getBoundingClientRect().bottom;
-        const skillsHeightWithinRail = skillsBottom - railTop;
-
-        if (skillsHeightWithinRail <= usablePageHeightPx) {
-          educationSection.classList.add('rail-break-before');
-        }
-      }
 
       async function loadCvData() {
         if (window.__CV_DATA__ && typeof window.__CV_DATA__ === "object") {
@@ -81,52 +46,12 @@
 
           const header = items.find((item) => window.CvRender.key(item.section) === "header") || {};
           const contacts = items.filter((item) => window.CvRender.key(item.section) === "contact");
-          const grouped = window.CvRender.groupBySection(items);
-
           const mainHost = document.getElementById("main-col");
           const railHost = document.getElementById("rail-col");
-          mainHost.innerHTML = "";
-          railHost.innerHTML = "";
 
           window.CvRender.renderHeader(document.getElementById("header"), header);
           window.CvRender.renderContact(document.getElementById("contact"), contacts, false);
-
-          const mainConfig = [
-            { key: "core competencies", title: "Core Competencies" },
-            { key: "work experience", title: "Work Experience" },
-            { key: "technical + it", title: "Technical + IT" }
-          ];
-          const railConfig = [
-            { key: "topline skills", title: "Skills" },
-            { key: "education", title: "Education" },
-            { key: "second page rail", title: null }
-          ];
-
-          mainConfig.forEach((cfg) => {
-            const sectionItems = grouped.get(cfg.key) || [];
-            if (sectionItems.length) {
-              const hideTitle = cfg.key === "core competencies";
-              window.CvRender.renderSection(mainHost, cfg.title, sectionItems, { hideEntryTitleWhenSameAsSection: hideTitle });
-            }
-            grouped.delete(cfg.key);
-          });
-
-          railConfig.forEach((cfg) => {
-            const sectionItems = grouped.get(cfg.key) || [];
-            if (!sectionItems.length) {
-              grouped.delete(cfg.key);
-              return;
-            }
-            if (cfg.key === "second page rail") window.CvRender.renderSecondRail(railHost, sectionItems);
-            else window.CvRender.renderSection(railHost, cfg.title, sectionItems, { hideEntryTitleWhenSameAsSection: false });
-            grouped.delete(cfg.key);
-          });
-
-          [...grouped.keys()].sort().forEach((extraKey) => {
-            window.CvRender.renderSection(mainHost, extraKey.replace(/\b\w/g, (c) => c.toUpperCase()), grouped.get(extraKey), { hideEntryTitleWhenSameAsSection: false });
-          });
-
-          applyRailEducationBreakIfSkillsFit();
+          window.CvRender.renderColumns(items, mainHost, railHost);
         } catch (error) {
           document.body.innerHTML = `<div style="padding:20px;color:#8b1111">${error.message}</div>`;
         }

--- a/cv-render.js
+++ b/cv-render.js
@@ -228,6 +228,7 @@
     sortItems,
     renderStandardCv,
     groupBySection,
+    renderColumns,
     renderSection,
     renderSecondRail,
     renderHeader,

--- a/scripts/build-cv-pdf.js
+++ b/scripts/build-cv-pdf.js
@@ -123,8 +123,7 @@ function renderSection(title, items, options = {}) {
     return renderEntry(item, { hideEntryTitle });
   }).join("\n");
 
-  const breakClass = options.breakBefore ? " rail-break-before" : "";
-  return `<section class=\"section${breakClass}\"><h3>${escapeHtml(title)}</h3>${entries}</section>`;
+  return `<section class=\"section\"><h3>${escapeHtml(title)}</h3>${entries}</section>`;
 }
 
 function groupBySection(items) {
@@ -202,8 +201,8 @@ function renderDocument(cv, cssHref) {
       </header>
       ${renderContact(contacts)}
       <section class="content">
-        <aside class="rail-col" id="rail-col">${railSections.join("\n")}</aside>
         <div class="main-col" id="main-col">${mainSections.join("\n")}</div>
+        <aside class="rail-col" id="rail-col">${railSections.join("\n")}</aside>
       </section>
     </main>
   </body>


### PR DESCRIPTION
### Motivation

- Runtime and static render paths had diverged: the preview page duplicated section-grouping logic and applied a measurement-based hack that injected page-breaks at runtime, while the static HTML generator used a different DOM order, producing nondeterministic Vivliostyle pagination. 
- Layout experiments (floats, mixed grid/table behavior and a forced `.rail-break-before`) caused the rail to be deferred or sections to be pushed to their own pages by the paged-media engine. 
- The objective is deterministic, high-quality paged output where header/contact are top of page 1, main column is left, rail appears on page 1 if it fits, entries are not split, and Core Competencies stays before Work Experience.

### Description

- Reconciled runtime and static rendering by making the preview page use the shared renderer: `cv-print.html` now calls `window.CvRender.renderColumns(items, mainHost, railHost)` instead of duplicating grouping/section logic and runtime break heuristics. 
- Stabilized layout with a two-column CSS grid in `cv-print.css` (`grid-template-columns: minmax(0, 1.95fr) minmax(0, 1fr)` and `column-gap: 6mm`) and kept `break-inside: avoid` on `.entry` and list items to prevent entry-splitting, while removing the brittle `.rail-break-before` forced-break rule. 
- Aligned static HTML generation in `scripts/build-cv-pdf.js` with the preview DOM order (main column before rail) and removed emission of an unused forced-break class; also kept the existing inline content markup and hidden Core Competencies entry title logic. 
- Exported `renderColumns` from `cv-render.js` so preview and other callers share the same ordering and composition logic, preserving typography sizes and rail header sizing constraints.

### Testing

- `node --check cv-render.js && node --check scripts/build-cv-pdf.js` — succeeded (syntax checks passed). 
- `npm run pdf:build` — attempted but failed in this environment because Vivliostyle/Playwright tried to download a Chromium binary and the download returned HTTP 403 from upstream, so full PDF generation could not complete here (environment limitation, not a code error). 
- `python3 -m http.server 4173` + Playwright screenshot script used to validate preview rendering and capture a visual proof screenshot at `artifacts/cv-print-preview.png` — succeeded. 

Changed files: `cv-print.html`, `cv-print.css`, `cv-render.js`, `scripts/build-cv-pdf.js`.

Commit: `4d25d0067c3f707e9e4562aa5edae324e109a05a`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afcc0cc34c83228594179325fba182)