### PR TITLE
fix: stabilize CV print/PDF pagination and CI commit flow

### DIFF
--- a/.github/workflows/build-cv-pdf.yml
+++ b/.github/workflows/build-cv-pdf.yml
@@ -111,8 +111,7 @@ jobs:
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add data/cv/*.json
-          git add -f dist/*.pdf
+          git add data/cv dist
           git commit -m "chore: update generated CV JSON and PDFs"
 
           branch="${GITHUB_REF_NAME:-main}"

--- a/cv-print.css
+++ b/cv-print.css
@@ -89,10 +89,12 @@ body {
 .content {
   margin-top: 6mm;
   width: 100%;
-  display: grid;
-  grid-template-columns: minmax(0, 1.95fr) minmax(0, 1fr);
-  column-gap: 6mm;
-  align-items: start;
+}
+
+.content::after {
+  content: "";
+  display: table;
+  clear: both;
 }
 
 .main-col,
@@ -112,10 +114,6 @@ body {
 
 .section {
   margin-bottom: 10px;
-}
-
-div#main-col > section,
-aside#rail-col > section.section {
   break-inside: auto;
   page-break-inside: auto;
 }
@@ -187,11 +185,6 @@ aside#rail-col > section.section {
 .rail-col .entry-date,
 .rail-col .entry-content { font-size: 12px; }
 
-.rail-break-before {
-  break-before: page;
-  page-break-before: always;
-}
-
 .skills-section .entry {
   margin-bottom: 2px;
 }
@@ -199,7 +192,6 @@ aside#rail-col > section.section {
 .skills-section .entry-content {
   margin-top: 0;
 }
-
 
 .print-actions {
   display: none;

--- a/cv-print.html
+++ b/cv-print.html
@@ -29,43 +29,6 @@
       const injectedSlug = String(window.__CV_SLUG__ || "").trim().toLowerCase();
       const slug = (query.get("cv") || injectedSlug || pathSlug || location.hash.replace(/^#/, "") || "coleman-davis").trim().toLowerCase();
 
-      function mmToPx(mm) {
-        const probe = document.createElement("div");
-        probe.style.width = `${mm}mm`;
-        probe.style.position = "absolute";
-        probe.style.visibility = "hidden";
-        document.body.appendChild(probe);
-        const px = probe.getBoundingClientRect().width;
-        probe.remove();
-        return px;
-      }
-
-      function applyRailEducationBreakIfSkillsFit() {
-        const root = document.getElementById("cv-print-root");
-        const railHost = document.getElementById("rail-col");
-        if (!root || !railHost) return;
-
-        const sections = [...railHost.querySelectorAll(':scope > .section')];
-        const skillsSection = sections.find((section) => section.querySelector('h3')?.textContent?.trim().toLowerCase() === 'skills');
-        const educationSection = sections.find((section) => section.querySelector('h3')?.textContent?.trim().toLowerCase() === 'education');
-
-        if (!skillsSection || !educationSection) return;
-
-        educationSection.classList.remove('rail-break-before');
-
-        const pageHeightPx = mmToPx(297);
-        const pageMarginPx = mmToPx(12);
-        const firstPageBottom = root.getBoundingClientRect().top + pageHeightPx - pageMarginPx;
-        const railTop = railHost.getBoundingClientRect().top;
-        const availableRailHeightOnFirstPage = firstPageBottom - railTop;
-        if (availableRailHeightOnFirstPage <= 0) return;
-
-        const skillsHeight = skillsSection.getBoundingClientRect().height;
-        if (skillsHeight <= availableRailHeightOnFirstPage) {
-          educationSection.classList.add('rail-break-before');
-        }
-      }
-
       async function loadCvData() {
         if (window.__CV_DATA__ && typeof window.__CV_DATA__ === "object") {
           return window.__CV_DATA__;
@@ -89,7 +52,6 @@
           window.CvRender.renderHeader(document.getElementById("header"), header);
           window.CvRender.renderContact(document.getElementById("contact"), contacts, false);
           window.CvRender.renderColumns(items, mainHost, railHost);
-          applyRailEducationBreakIfSkillsFit();
         } catch (error) {
           document.body.innerHTML = `<div style="padding:20px;color:#8b1111">${error.message}</div>`;
         }

--- a/scripts/build-cv-pdf.js
+++ b/scripts/build-cv-pdf.js
@@ -80,6 +80,15 @@ function sortItems(items) {
   });
 }
 
+
+function titleCase(value) {
+  return String(value || "")
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
 function formatApDate(value) {
   const input = String(value || "").trim();
   if (!input) return "";
@@ -212,8 +221,7 @@ function renderDocument(cv, cssHref) {
 
   const extraKeys = [...grouped.keys()].sort();
   for (const extraKey of extraKeys) {
-    const title = extraKey.replace(/\b\w/g, (c) => c.toUpperCase());
-    mainSections.push(renderSection(title, grouped.get(extraKey) || []));
+    mainSections.push(renderSection(titleCase(extraKey), grouped.get(extraKey) || []));
   }
 
   return `<!doctype html>
@@ -237,45 +245,6 @@ function renderDocument(cv, cssHref) {
         <aside class="rail-col" id="rail-col">${railSections.join("\n")}</aside>
       </section>
     </main>
-    <script>
-      function mmToPx(mm) {
-        const probe = document.createElement("div");
-        probe.style.width = mm + "mm";
-        probe.style.position = "absolute";
-        probe.style.visibility = "hidden";
-        document.body.appendChild(probe);
-        const px = probe.getBoundingClientRect().width;
-        probe.remove();
-        return px;
-      }
-
-      function applyRailEducationBreakIfSkillsFit() {
-        const root = document.getElementById("cv-print-root");
-        const railHost = document.getElementById("rail-col");
-        if (!root || !railHost) return;
-
-        const sections = [...railHost.querySelectorAll(':scope > .section')];
-        const skillsSection = sections.find((section) => section.querySelector('h3')?.textContent?.trim().toLowerCase() === 'skills');
-        const educationSection = sections.find((section) => section.querySelector('h3')?.textContent?.trim().toLowerCase() === 'education');
-        if (!skillsSection || !educationSection) return;
-
-        educationSection.classList.remove('rail-break-before');
-
-        const pageHeightPx = mmToPx(297);
-        const pageMarginPx = mmToPx(12);
-        const firstPageBottom = root.getBoundingClientRect().top + pageHeightPx - pageMarginPx;
-        const railTop = railHost.getBoundingClientRect().top;
-        const availableRailHeightOnFirstPage = firstPageBottom - railTop;
-        if (availableRailHeightOnFirstPage <= 0) return;
-
-        const skillsHeight = skillsSection.getBoundingClientRect().height;
-        if (skillsHeight <= availableRailHeightOnFirstPage) {
-          educationSection.classList.add('rail-break-before');
-        }
-      }
-
-      applyRailEducationBreakIfSkillsFit();
-    </script>
   </body>
 </html>`;
 }


### PR DESCRIPTION
### Motivation
- Runtime measurement-based pagination (`applyRailEducationBreakIfSkillsFit`) produced non-deterministic page breaks that made preview and static PDF output diverge.  
- Print layout mixed grid and float strategies, which caused brittle behavior in paged renderers like Vivliostyle.  
- The static renderer duplicated the dynamic pagination logic and the CI commit staging used globs that can fail when a pattern has no matches.

### Description
- Removed the measurement-based pagination heuristic by deleting `applyRailEducationBreakIfSkillsFit` and the `mmToPx` measurement code from `cv-print.html` and the static HTML emitted by `scripts/build-cv-pdf.js`, so pagination is driven by CSS break rules only.  
- Simplified paged layout in `cv-print.css` to use float-based two-column layout for print (while keeping a grid layout for on-screen preview) and kept `break-inside: avoid` on `.entry` and list items to preserve entry atomicity.  
- Aligned static renderer structure with runtime by removing injected pagination scripts and adding a `titleCase` helper in `scripts/build-cv-pdf.js` so section titles match runtime rendering.  
- Made CI commit staging robust by adding `data/cv` and `dist` paths directly in the workflow (`.github/workflows/build-cv-pdf.yml`) to avoid empty-glob failures during issue-trigger runs.

### Testing
- Ran syntax/type checks with `node --check scripts/build-cv-pdf.js` and `node --check cv-render.js`, and both completed successfully.  
- Attempted `npm run pdf:build`, but the Vivliostyle/Playwright step failed to download Chromium (HTTP 403) so PDF generation was blocked in this environment (warning).  
- Launched a local preview with `python -m http.server 4173` and validated the live preview rendering using an automated Playwright script that produced a screenshot (success).  
- Ensured `npm` scripts remain unchanged: `pdf:build` still targets `dist/<slug>.pdf` and the workflow still uploads `dist/*.pdf` as artifacts (no automated failure observed in workflow file changes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afe2bd3e6c83228f85e1c6763fa754)