### PR TITLE
Improve rail-column pagination and skills handling for CV print layout

### DIFF
--- a/cv-print.css
+++ b/cv-print.css
@@ -100,18 +100,34 @@ body {
 .main-col,
 .rail-col {
   min-width: 0;
-  float: left;
 }
 
-.main-col { grid-column: 1; }
-.rail-col { grid-column: 2; }
+.main-col {
+  float: left;
+  width: 64%;
+}
+
+.rail-col {
+  float: right;
+  width: 32%;
+}
+
+.rail-page1,
+.rail-overflow {
+  min-width: 0;
+}
+
+.rail-overflow {
+  clear: both;
+}
+
 
 .section {
   margin-bottom: 10px;
 }
 
 div#main-col > section,
-aside#rail-col > section.section {
+#rail-col .section {
   break-inside: auto;
   page-break-inside: auto;
 }
@@ -183,9 +199,17 @@ aside#rail-col > section.section {
 .rail-col .entry-date,
 .rail-col .entry-content { font-size: 12px; }
 
-.rail-break-before {
+.rail-page-break {
   break-before: page;
   page-break-before: always;
+}
+
+.skills-section .entry {
+  margin-bottom: 2px;
+}
+
+.skills-section .entry-content {
+  margin-top: 0;
 }
 
 
@@ -226,6 +250,26 @@ aside#rail-col > section.section {
     box-shadow: 0 8px 28px rgba(15, 23, 42, 0.2), 0 2px 8px rgba(15, 23, 42, 0.12);
     padding: var(--page-margin);
   }
+
+  .content {
+    display: grid;
+    grid-template-columns: minmax(0, 1.95fr) minmax(0, 1fr);
+    column-gap: 6mm;
+    align-items: start;
+  }
+
+  .content::after {
+    content: none;
+  }
+
+  .main-col,
+  .rail-col {
+    float: none;
+    width: auto;
+  }
+
+  .main-col { grid-column: 1; }
+  .rail-col { grid-column: 2; }
 }
 
 @media print {

--- a/cv-print.html
+++ b/cv-print.html
@@ -30,40 +30,6 @@
       const slug = (query.get("cv") || injectedSlug || pathSlug || location.hash.replace(/^#/, "") || "coleman-davis").trim().toLowerCase();
 
 
-      function mmToPx(mm) {
-        const probe = document.createElement("div");
-        probe.style.width = `${mm}mm`;
-        probe.style.position = "absolute";
-        probe.style.visibility = "hidden";
-        document.body.appendChild(probe);
-        const px = probe.getBoundingClientRect().width;
-        probe.remove();
-        return px;
-      }
-
-      function applyRailEducationBreakIfSkillsFit() {
-        const railHost = document.getElementById("rail-col");
-        if (!railHost) return;
-
-        const sections = [...railHost.querySelectorAll(':scope > .section')];
-        const skillsSection = sections.find((section) => section.querySelector('h3')?.textContent?.trim().toLowerCase() === 'skills');
-        const educationSection = sections.find((section) => section.querySelector('h3')?.textContent?.trim().toLowerCase() === 'education');
-
-        if (!skillsSection || !educationSection) return;
-
-        const firstPageHeightPx = mmToPx(297);
-        const pageMarginPx = mmToPx(12);
-        const usablePageHeightPx = firstPageHeightPx - (pageMarginPx * 2);
-
-        const railTop = railHost.getBoundingClientRect().top;
-        const skillsBottom = skillsSection.getBoundingClientRect().bottom;
-        const skillsHeightWithinRail = skillsBottom - railTop;
-
-        if (skillsHeightWithinRail <= usablePageHeightPx) {
-          educationSection.classList.add('rail-break-before');
-        }
-      }
-
       async function loadCvData() {
         if (window.__CV_DATA__ && typeof window.__CV_DATA__ === "object") {
           return window.__CV_DATA__;
@@ -81,52 +47,13 @@
 
           const header = items.find((item) => window.CvRender.key(item.section) === "header") || {};
           const contacts = items.filter((item) => window.CvRender.key(item.section) === "contact");
-          const grouped = window.CvRender.groupBySection(items);
-
           const mainHost = document.getElementById("main-col");
           const railHost = document.getElementById("rail-col");
-          mainHost.innerHTML = "";
-          railHost.innerHTML = "";
 
           window.CvRender.renderHeader(document.getElementById("header"), header);
           window.CvRender.renderContact(document.getElementById("contact"), contacts, false);
-
-          const mainConfig = [
-            { key: "core competencies", title: "Core Competencies" },
-            { key: "work experience", title: "Work Experience" },
-            { key: "technical + it", title: "Technical + IT" }
-          ];
-          const railConfig = [
-            { key: "topline skills", title: "Skills" },
-            { key: "education", title: "Education" },
-            { key: "second page rail", title: null }
-          ];
-
-          mainConfig.forEach((cfg) => {
-            const sectionItems = grouped.get(cfg.key) || [];
-            if (sectionItems.length) {
-              const hideTitle = cfg.key === "core competencies";
-              window.CvRender.renderSection(mainHost, cfg.title, sectionItems, { hideEntryTitleWhenSameAsSection: hideTitle });
-            }
-            grouped.delete(cfg.key);
-          });
-
-          railConfig.forEach((cfg) => {
-            const sectionItems = grouped.get(cfg.key) || [];
-            if (!sectionItems.length) {
-              grouped.delete(cfg.key);
-              return;
-            }
-            if (cfg.key === "second page rail") window.CvRender.renderSecondRail(railHost, sectionItems);
-            else window.CvRender.renderSection(railHost, cfg.title, sectionItems, { hideEntryTitleWhenSameAsSection: false });
-            grouped.delete(cfg.key);
-          });
-
-          [...grouped.keys()].sort().forEach((extraKey) => {
-            window.CvRender.renderSection(mainHost, extraKey.replace(/\b\w/g, (c) => c.toUpperCase()), grouped.get(extraKey), { hideEntryTitleWhenSameAsSection: false });
-          });
-
-          applyRailEducationBreakIfSkillsFit();
+          window.CvRender.renderColumns(items, mainHost, railHost);
+          window.CvRender.packRailForPagedLayout(document.getElementById("cv-print-root"), railHost);
         } catch (error) {
           document.body.innerHTML = `<div style="padding:20px;color:#8b1111">${error.message}</div>`;
         }

--- a/cv-render.js
+++ b/cv-render.js
@@ -136,9 +136,10 @@
     if (!items.length) return;
     const section = document.createElement("section");
     section.className = "section";
-    section.innerHTML = `<h3>${title}</h3>`;
 
     const normalizedTitle = String(title || "").trim().toLowerCase();
+    if (normalizedTitle === "skills") section.classList.add("skills-section");
+    section.innerHTML = `<h3>${title}</h3>`;
     sortItems(items).forEach((item) => {
       const itemTitle = String(item?.title || "").trim().toLowerCase();
       const hideEntryTitle = options.hideEntryTitleWhenSameAsSection && itemTitle && itemTitle === normalizedTitle;
@@ -175,6 +176,86 @@
     return grouped;
   }
 
+
+  function expandSkillsItems(items) {
+    const expanded = [];
+    for (const item of items) {
+      const content = String(item?.content || "");
+      const bulletLines = content
+        .split(/\r?\n/)
+        .map((line) => line.trim())
+        .filter((line) => /^[-*]\s+/.test(line));
+
+      if (bulletLines.length >= 2) {
+        bulletLines.forEach((line, index) => {
+          expanded.push({
+            ...item,
+            title: "",
+            subtitle: "",
+            location: "",
+            start: "",
+            end: "",
+            dispdate: "",
+            manualsort: item.manualsort ? `${item.manualsort}.${String(index + 1).padStart(3, "0")}` : "",
+            content: line
+          });
+        });
+      } else {
+        expanded.push(item);
+      }
+    }
+    return expanded;
+  }
+
+  function packRailForPagedLayout(root, railHost) {
+    if (!root || !railHost) return;
+
+    const page1 = railHost.querySelector(":scope > .rail-page1");
+    const overflow = railHost.querySelector(":scope > .rail-overflow");
+    if (!page1 || !overflow) return;
+
+    const sections = [...page1.querySelectorAll(":scope > .section")];
+    const skillsSection = sections.find((section) => section.querySelector("h3")?.textContent?.trim().toLowerCase() === "skills");
+    const educationSection = sections.find((section) => section.querySelector("h3")?.textContent?.trim().toLowerCase() === "education");
+    if (!skillsSection) return;
+
+    const overflowSkills = document.createElement("section");
+    overflowSkills.className = "section skills-section";
+    overflowSkills.innerHTML = "<h3>Skills</h3>";
+
+    const mmProbe = document.createElement("div");
+    mmProbe.style.width = "1mm";
+    mmProbe.style.position = "absolute";
+    mmProbe.style.visibility = "hidden";
+    document.body.appendChild(mmProbe);
+    const pxPerMm = mmProbe.getBoundingClientRect().width || 3.7795;
+    mmProbe.remove();
+
+    const firstPageBottom = root.getBoundingClientRect().top + (297 - 12) * pxPerMm;
+    const page1Top = page1.getBoundingClientRect().top;
+    const availableHeight = firstPageBottom - page1Top;
+
+    if (availableHeight > 0) {
+      while (skillsSection.querySelectorAll(":scope > .entry").length > 1 && page1.getBoundingClientRect().height > availableHeight) {
+        const entries = skillsSection.querySelectorAll(":scope > .entry");
+        const last = entries[entries.length - 1];
+        overflowSkills.appendChild(last);
+      }
+    }
+
+    if (overflowSkills.querySelector(":scope > .entry")) {
+      const movedEntries = [...overflowSkills.querySelectorAll(":scope > .entry")];
+      overflowSkills.innerHTML = "<h3>Skills</h3>";
+      movedEntries.reverse().forEach((entry) => overflowSkills.appendChild(entry));
+      overflow.prepend(overflowSkills);
+    }
+
+    if (educationSection) overflow.appendChild(educationSection);
+
+    if (overflow.children.length) overflow.classList.add("rail-page-break");
+    else overflow.classList.remove("rail-page-break");
+  }
+
   function renderColumns(items, mainHost, railHost) {
     const grouped = groupBySection(items);
     mainHost.innerHTML = "";
@@ -186,11 +267,6 @@
       { key: "technical + it", title: "Technical + IT" }
     ];
 
-    const railConfig = [
-      { key: "topline skills", title: "Skills" },
-      { key: "education", title: "Education" },
-      { key: "second page rail", title: null }
-    ];
 
     mainConfig.forEach((cfg) => {
       const sectionItems = grouped.get(cfg.key) || [];
@@ -199,16 +275,23 @@
       grouped.delete(cfg.key);
     });
 
-    railConfig.forEach((cfg) => {
-      const sectionItems = grouped.get(cfg.key) || [];
-      if (!sectionItems.length) {
-        grouped.delete(cfg.key);
-        return;
-      }
-      if (cfg.key === "second page rail") renderSecondRail(railHost, sectionItems);
-      else renderSection(railHost, cfg.title, sectionItems, { hideEntryTitleWhenSameAsSection: false });
-      grouped.delete(cfg.key);
-    });
+    const railPage1 = document.createElement("div");
+    railPage1.className = "rail-page1";
+    const railOverflow = document.createElement("div");
+    railOverflow.className = "rail-overflow";
+    railHost.appendChild(railPage1);
+    railHost.appendChild(railOverflow);
+
+    const skillsItems = grouped.get("topline skills") || [];
+    const educationItems = grouped.get("education") || [];
+    const secondRailItems = grouped.get("second page rail") || [];
+    renderSection(railPage1, "Skills", expandSkillsItems(skillsItems), { hideEntryTitleWhenSameAsSection: false });
+    renderSection(railPage1, "Education", educationItems, { hideEntryTitleWhenSameAsSection: false });
+    renderSecondRail(railOverflow, secondRailItems);
+
+    grouped.delete("topline skills");
+    grouped.delete("education");
+    grouped.delete("second page rail");
 
     [...grouped.keys()].sort().forEach((extraKey) => {
       renderSection(mainHost, titleCase(extraKey), grouped.get(extraKey), { hideEntryTitleWhenSameAsSection: false });
@@ -228,6 +311,8 @@
     sortItems,
     renderStandardCv,
     groupBySection,
+    packRailForPagedLayout,
+    renderColumns,
     renderSection,
     renderSecondRail,
     renderHeader,

--- a/scripts/build-cv-pdf.js
+++ b/scripts/build-cv-pdf.js
@@ -123,8 +123,8 @@ function renderSection(title, items, options = {}) {
     return renderEntry(item, { hideEntryTitle });
   }).join("\n");
 
-  const breakClass = options.breakBefore ? " rail-break-before" : "";
-  return `<section class=\"section${breakClass}\"><h3>${escapeHtml(title)}</h3>${entries}</section>`;
+  const sectionClass = normalizedTitle === "skills" ? "section skills-section" : "section";
+  return `<section class=\"${sectionClass}\"><h3>${escapeHtml(title)}</h3>${entries}</section>`;
 }
 
 function groupBySection(items) {
@@ -136,6 +136,37 @@ function groupBySection(items) {
     grouped.get(section).push(item);
   }
   return grouped;
+}
+
+
+function expandSkillsItems(items) {
+  const expanded = [];
+  for (const item of items) {
+    const content = String(item?.content || "");
+    const bulletLines = content
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((line) => /^[-*]\s+/.test(line));
+
+    if (bulletLines.length >= 2) {
+      bulletLines.forEach((line, index) => {
+        expanded.push({
+          ...item,
+          title: "",
+          subtitle: "",
+          location: "",
+          start: "",
+          end: "",
+          dispdate: "",
+          manualsort: item.manualsort ? `${item.manualsort}.${String(index + 1).padStart(3, "0")}` : "",
+          content: line
+        });
+      });
+    } else {
+      expanded.push(item);
+    }
+  }
+  return expanded;
 }
 
 function renderContact(contacts) {
@@ -156,7 +187,7 @@ function renderDocument(cv, cssHref) {
     { key: "technical + it", title: "Technical + IT", hideTitle: false }
   ];
 
-  const skillsItems = grouped.get("topline skills") || [];
+  const skillsItems = expandSkillsItems(grouped.get("topline skills") || []);
   const educationItems = grouped.get("education") || [];
 
   const mainSections = [];
@@ -166,17 +197,15 @@ function renderDocument(cv, cssHref) {
     mainSections.push(renderSection(cfg.title, sectionItems, { hideEntryTitleWhenSameAsSection: cfg.hideTitle }));
   }
 
-  const railSections = [];
-  railSections.push(renderSection("Skills", skillsItems));
-  railSections.push(renderSection("Education", educationItems));
   grouped.delete("topline skills");
   grouped.delete("education");
 
   const secondRail = grouped.get("second page rail") || [];
   grouped.delete("second page rail");
+  const secondRailSections = [];
   for (const item of sortItems(secondRail)) {
     if (!item.title) continue;
-    railSections.push(`<section class=\"section\"><h3>${escapeHtml(item.title)}</h3><div class=\"entry-content\">${markdownToHtml(item.content || "")}</div></section>`);
+    secondRailSections.push(`<section class="section"><h3>${escapeHtml(item.title)}</h3><div class="entry-content">${markdownToHtml(item.content || "")}</div></section>`);
   }
 
   const extraKeys = [...grouped.keys()].sort();
@@ -184,6 +213,13 @@ function renderDocument(cv, cssHref) {
     const title = extraKey.replace(/\b\w/g, (c) => c.toUpperCase());
     mainSections.push(renderSection(title, grouped.get(extraKey) || []));
   }
+
+  const railPage1Html = `${renderSection("Skills", skillsItems)}${renderSection("Education", educationItems)}`;
+  const railOverflowHtml = secondRailSections.join("\n");
+  const railSections = [
+    `<div class="rail-page1">${railPage1Html}</div>`,
+    `<div class="rail-overflow">${railOverflowHtml}</div>`
+  ];
 
   return `<!doctype html>
 <html lang="en">
@@ -206,6 +242,58 @@ function renderDocument(cv, cssHref) {
         <div class="main-col" id="main-col">${mainSections.join("\n")}</div>
       </section>
     </main>
+    <script>
+      (function packRailForPagedLayout() {
+        const root = document.getElementById("cv-print-root");
+        const railHost = document.getElementById("rail-col");
+        if (!root || !railHost) return;
+
+        const page1 = railHost.querySelector(":scope > .rail-page1");
+        const overflow = railHost.querySelector(":scope > .rail-overflow");
+        if (!page1 || !overflow) return;
+
+        const sections = [...page1.querySelectorAll(":scope > .section")];
+        const skillsSection = sections.find((section) => section.querySelector("h3")?.textContent?.trim().toLowerCase() === "skills");
+        const educationSection = sections.find((section) => section.querySelector("h3")?.textContent?.trim().toLowerCase() === "education");
+        if (!skillsSection) return;
+
+        const overflowSkills = document.createElement("section");
+        overflowSkills.className = "section skills-section";
+        overflowSkills.innerHTML = "<h3>Skills</h3>";
+
+        const mmProbe = document.createElement("div");
+        mmProbe.style.width = "1mm";
+        mmProbe.style.position = "absolute";
+        mmProbe.style.visibility = "hidden";
+        document.body.appendChild(mmProbe);
+        const pxPerMm = mmProbe.getBoundingClientRect().width || 3.7795;
+        mmProbe.remove();
+
+        const firstPageBottom = root.getBoundingClientRect().top + (297 - 12) * pxPerMm;
+        const page1Top = page1.getBoundingClientRect().top;
+        const availableHeight = firstPageBottom - page1Top;
+
+        if (availableHeight > 0) {
+          while (skillsSection.querySelectorAll(":scope > .entry").length > 1 && page1.getBoundingClientRect().height > availableHeight) {
+            const entries = skillsSection.querySelectorAll(":scope > .entry");
+            const last = entries[entries.length - 1];
+            overflowSkills.appendChild(last);
+          }
+        }
+
+        if (overflowSkills.querySelector(":scope > .entry")) {
+          const movedEntries = [...overflowSkills.querySelectorAll(":scope > .entry")];
+          overflowSkills.innerHTML = "<h3>Skills</h3>";
+          movedEntries.reverse().forEach((entry) => overflowSkills.appendChild(entry));
+          overflow.prepend(overflowSkills);
+        }
+
+        if (educationSection) overflow.appendChild(educationSection);
+
+        if (overflow.children.length) overflow.classList.add("rail-page-break");
+        else overflow.classList.remove("rail-page-break");
+      })();
+    </script>
   </body>
 </html>`;
 }


### PR DESCRIPTION
### Motivation
- Make the right-hand rail column paginate cleanly across pages when printing, preventing awkward cutoff of the Skills and Education sections. 
- Treat multiline bullet lists in the Skills section as discrete entries to allow finer-grained pagination. 
- Simplify and unify client and server-side rendering so the packed rail layout is produced both in-browser and in the prebuilt PDF HTML.

### Description
- Update layout/CSS: convert `.content` to a two-column grid for screen and restore float-based columns for print, introduce `.rail-page1` and `.rail-overflow` wrappers, rename/adjust rail page-break class to `.rail-page-break`, and add `.skills-section` tweaks. 
- Simplify `cv-print.html` by removing old measurement/heuristic code and call `CvRender.renderColumns` and `CvRender.packRailForPagedLayout` to build columns at runtime. 
- Add `expandSkillsItems` to split multiline bullet content into individual skill entries and update `renderSection` to mark `skills` with `.skills-section`. 
- Implement `packRailForPagedLayout` in `cv-render.js` to move overflowing skill entries from `.rail-page1` into `.rail-overflow` (and append `Education` there when needed). 
- Mirror the new behavior in `scripts/build-cv-pdf.js`: expand skills during static HTML generation, output `.rail-page1` and `.rail-overflow` markup, and inject a small inline script to run the same packing logic when the generated HTML is measured before PDF generation.

### Testing
- Built the PDF using the repository build helper by running `node scripts/build-cv-pdf.js` for the default slug and the tool completed, producing `dist/<slug>.pdf` (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afcc0cc34c83228594179325fba182)