### PR TITLE
fix: reset CV PDF pagination to deterministic paged-media flow

### DIFF
--- a/cv-print.css
+++ b/cv-print.css
@@ -100,15 +100,8 @@ body {
   min-width: 0;
 }
 
-.main-col {
-  float: left;
-  width: 64%;
-}
-
-.rail-col {
-  float: right;
-  width: 32%;
-}
+.main-col { grid-column: 1; }
+.rail-col { grid-column: 2; }
 
 .section {
   margin-bottom: 10px;
@@ -249,12 +242,8 @@ body {
 
   .main-col,
   .rail-col {
-    float: none;
     width: auto;
   }
-
-  .main-col { grid-column: 1; }
-  .rail-col { grid-column: 2; }
 }
 
 @media print {

--- a/scripts/build-cv-pdf.js
+++ b/scripts/build-cv-pdf.js
@@ -240,40 +240,6 @@ function renderDocument(cv, cssHref) {
         <aside class="rail-col" id="rail-col">${railSections.join("\n")}</aside>
       </section>
     </main>
-    <script>
-      (function applyRailEducationBreakIfSkillsFit() {
-        const root = document.getElementById("cv-print-root");
-        const railHost = document.getElementById("rail-col");
-        if (!root || !railHost) return;
-
-        const sections = [...railHost.querySelectorAll(':scope > .section')];
-        const skillsSection = sections.find((section) => section.querySelector('h3')?.textContent?.trim().toLowerCase() === 'skills');
-        const educationSection = sections.find((section) => section.querySelector('h3')?.textContent?.trim().toLowerCase() === 'education');
-        if (!skillsSection || !educationSection) return;
-
-        educationSection.classList.remove('rail-page-break');
-
-        const mmProbe = document.createElement("div");
-        mmProbe.style.width = "1mm";
-        mmProbe.style.position = "absolute";
-        mmProbe.style.visibility = "hidden";
-        document.body.appendChild(mmProbe);
-        const pxPerMm = mmProbe.getBoundingClientRect().width || 3.7795;
-        mmProbe.remove();
-
-        const pageHeightPx = 297 * pxPerMm;
-        const pageMarginPx = 12 * pxPerMm;
-        const firstPageBottom = root.getBoundingClientRect().top + pageHeightPx - pageMarginPx;
-        const railTop = railHost.getBoundingClientRect().top;
-        const availableRailHeightOnFirstPage = firstPageBottom - railTop;
-        if (availableRailHeightOnFirstPage <= 0) return;
-
-        const skillsHeight = skillsSection.getBoundingClientRect().height;
-        if (skillsHeight <= availableRailHeightOnFirstPage) {
-          educationSection.classList.add('rail-page-break');
-        }
-      })();
-    </script>
   </body>
 </html>`;
 }


### PR DESCRIPTION
### Motivation

- The static PDF build included a post-render geometry script and the print CSS mixed `float` with grid, creating non-deterministic Vivliostyle pagination that pushed rail content (Skills) to page 2 while leaving empty space on page 1.
- The goal is to produce a stable, CSS-driven paged-media layout (two-column grid) that matches the expected page 1 composition without runtime geometry hacks.

### Description

- Removed the inline post-render geometry mutation (`applyRailEducationBreakIfSkillsFit`) from the static HTML generated in `scripts/build-cv-pdf.js` so Vivliostyle receives deterministic content only. 
- Normalized the print layout in `cv-print.css` by removing `float`-based column sizing and enforcing a single CSS grid two-column model (`.main-col` and `.rail-col` use `grid-column`), which prevents competing layout signals during pagination. 
- Preserved existing renderer ordering and section-level break behavior implemented in `cv-render.js` (Core Competencies before Work Experience and entry-level break-avoid rules) so content semantics remain unchanged. 
- Commit created: `2113f72`.

### Testing

- `node --check cv-render.js` ran and succeeded. 
- `node --check scripts/build-cv-pdf.js` ran and succeeded. 
- `npm run pdf:build` was invoked but failed in this environment with Vivliostyle/Playwright failing to download Chromium (HTTP 403), so PDF binary generation could not be completed here (environmental warning). 
- Local preview served with `python3 -m http.server 4173` and a Playwright capture of `http://127.0.0.1:4173/cv-print.html?cv=coleman-davis` produced a screenshot artifact confirming the corrected grid-based page 1 rendering.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0161e14888322af1ced8e59c5c579)