### PR TITLE
Add AI feedback workflow, embeddable CV UI, and refactor rendering + PDF pipeline

### DIFF
--- a/.github/workflows/build-cv-pdf.yml
+++ b/.github/workflows/build-cv-pdf.yml
@@ -120,8 +120,7 @@ jobs:
 
           for attempt in 1 2 3; do
             echo "Push attempt ${attempt} to ${branch}"
-            git fetch origin "$branch"
-            git pull --rebase --autostash origin "$branch" || (git rebase --abort && false)
+            git pull --no-rebase -X ours origin "$branch"
             if git push origin "HEAD:${branch}"; then
               echo "Push succeeded"
               exit 0

--- a/.github/workflows/cv-ai-feedback.yml
+++ b/.github/workflows/cv-ai-feedback.yml
@@ -1,0 +1,107 @@
+name: CV AI Feedback
+
+on:
+  workflow_dispatch:
+  issues:
+    types: [opened, edited, reopened]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  ai-feedback:
+    runs-on: ubuntu-latest
+    env:
+      EXPECTED_ISSUE_AUTHOR: cpd4f
+
+    steps:
+      - name: Check guard conditions (issue runs)
+        if: github.event_name == 'issues'
+        id: guard
+        env:
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_AUTHOR: ${{ github.event.issue.user.login }}
+          ISSUE_AUTHOR_URL: ${{ github.event.issue.user.html_url }}
+        run: |
+          normalize_user() {
+            local value
+            value="$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')"
+            value="${value#@}"
+            value="${value#https://github.com/}"
+            value="${value#http://github.com/}"
+            value="${value%/}"
+            printf '%s' "$value"
+          }
+
+          expected="$(normalize_user "$EXPECTED_ISSUE_AUTHOR")"
+          actual_login="$(normalize_user "$ISSUE_AUTHOR")"
+          actual_from_url="$(normalize_user "$ISSUE_AUTHOR_URL")"
+
+          title_ok=false
+          author_ok=false
+
+          issue_title_upper="$(printf '%s' "$ISSUE_TITLE" | tr '[:lower:]' '[:upper:]')"
+          if [[ "$issue_title_upper" == CV_UPDATE* ]]; then
+            title_ok=true
+          fi
+
+          if [[ "$actual_login" == "$expected" || "$actual_from_url" == "$expected" ]]; then
+            author_ok=true
+          fi
+
+          if [[ "$title_ok" == true && "$author_ok" == true ]]; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            echo "Skipping AI feedback automation: guard did not pass."
+          fi
+
+      - name: Stop early when issue guard fails
+        if: github.event_name == 'issues' && steps.guard.outputs.should_run != 'true'
+        run: exit 0
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install dependencies
+        run: npm install --no-audit --no-fund
+
+      - name: Run AI feedback for triggering CV
+        env:
+          AIRTABLE_PAT: ${{ secrets.AIRTABLE_PAT }}
+          AIRTABLE_BASE_ID: ${{ secrets.AIRTABLE_BASE_ID }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
+        run: npm run ai:feedback
+
+      - name: Comment success
+        if: github.event_name == 'issues' && success()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `✅ AI CV feedback completed and written to Airtable field \`Overall AI Feedback\`.`
+            });
+
+      - name: Comment failure
+        if: github.event_name == 'issues' && failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `❌ AI CV feedback run failed. Please review workflow logs: ${runUrl}`
+            });

--- a/README.md
+++ b/README.md
@@ -1,0 +1,252 @@
+# CV Builder
+
+A static CV publishing pipeline that:
+
+- Pulls CV records/items from Airtable into normalized JSON.
+- Renders CVs for web (`/cv?cv=<slug>`), print (`/cv-print.html`), and external embed (`cv-embed.js`).
+- Builds PDF files into `dist/<slug>.pdf` using Vivliostyle.
+- Optionally generates AI feedback for a single triggering CV and writes it back to Airtable.
+
+---
+
+## Repository Structure
+
+- `scripts/build-cv-json.js` — Airtable ➜ `data/cv/*.json` exporter.
+- `scripts/build-cv-pdf.js` — JSON ➜ paginated HTML ➜ `dist/*.pdf` builder.
+- `scripts/run-cv-ai-feedback.js` — Airtable CV ➜ OpenAI feedback ➜ Airtable update (`Overall AI Feedback`).
+- `cv-render.js` — browser renderer shared by viewer/print/embed flows.
+- `cv.html` — viewer page for a single CV with a PDF link.
+- `cv-feedback.html` — CV + AI feedback review page (overall and item-level feedback side-by-side).
+- `cv-print.html` + `cv-print.css` — print-focused paginated view.
+- `cv-embed.js` + `cv-embed.html` — non-iframe embeddable widget + usage/instructions page.
+- `.github/workflows/cv-ai-feedback.yml` — issue/manual-trigger workflow for AI feedback runs.
+
+---
+
+## High-Level Flow
+
+1. **Data ingest**: Airtable records are fetched and normalized into `data/cv/<slug>.json`.
+2. **Render paths**:
+   - Web viewer (`cv.html`) renders CV content client-side.
+   - Print page (`cv-print.html`) renders paginated layout client-side.
+   - Embed script (`cv-embed.js`) renders inside Shadow DOM on external sites.
+3. **PDF build**: `scripts/build-cv-pdf.js` transforms JSON into print HTML and runs Vivliostyle to generate `dist/<slug>.pdf`.
+4. **AI feedback (optional)**: workflow/script fetches the triggering CV, sends structured prompt to OpenAI, writes output to Airtable `Overall AI Feedback`.
+
+---
+
+## Prerequisites
+
+- Node.js 20+ (ESM project).
+- npm.
+- Airtable PAT + base/table identifiers for Airtable scripts.
+- Optional: `OPENAI_API_KEY` for AI feedback flow.
+
+Install dependencies:
+
+```bash
+npm install
+```
+
+---
+
+## npm Commands
+
+```bash
+npm run build:json    # Build CV JSON files from Airtable
+npm run pdf:build     # Build PDFs from data/cv/*.json
+npm run pdf:preview   # Open Vivliostyle preview for cv-print.html
+npm run ai:feedback   # Run AI feedback script for the triggering CV
+```
+
+---
+
+## Airtable JSON Build (`build:json`)
+
+### What it does
+
+- Reads CV header-level data from the `CVs` table.
+- Reads itemized content from the `CV Items` table.
+- Normalizes rich-text field variants.
+- Writes canonical JSON to `data/cv/<slug>.json`.
+
+### Trigger targeting logic
+
+The script can resolve a specific CV record ID from:
+
+- Issue title pattern like `CV_UPDATE recXXXXXXXXXXXXXX`.
+- Issue body line like `recordid recXXXXXXXXXXXXXX`.
+
+If configured, it can also build all published CVs.
+
+### Environment variables
+
+Required for Airtable access:
+
+- `AIRTABLE_PAT`
+- `AIRTABLE_BASE_ID`
+
+Optional/config:
+
+- `CVS_TABLE_NAME` (default: `CVs`)
+- `CV_ITEMS_TABLE_NAME` (default: `CV Items`)
+- `CVS_TABLE_ID`
+- `CV_ITEMS_TABLE_ID`
+- `ISSUE_TITLE`
+- `ISSUE_BODY`
+- `BUILD_ALL_CVS=true|false`
+
+### CV Footer behavior
+
+`build-cv-json` reads footer content from the CV table using `CV_Footer` (also supports fallback matching), and emits it in JSON as section `footer` for downstream renderers.
+
+---
+
+## Web Viewer (`cv.html`)
+
+- Route format: `/cv?cv=<slug>`.
+- Loads `data/cv/<slug>.json`.
+- Renders CV content using `CvRender.renderStandardCv`.
+- Provides a single action to open `dist/<slug>.pdf` in a new tab.
+
+---
+
+## Print View (`cv-print.html` + `cv-print.css`)
+
+- Route format: `/cv-print.html?cv=<slug>`.
+- Uses paginated rendering (`CvRender.renderPaginatedCv`).
+- CSS defines print-friendly multi-block layout and footer area.
+- Intended for previewing/validating print layout behavior and as a design reference for PDF generation.
+
+---
+
+## PDF Build (`pdf:build`)
+
+### What it does
+
+- Reads each `data/cv/*.json` file.
+- Generates an HTML document with the same layout model as print rendering.
+- Calls `npx vivliostyle build` to output `dist/<slug>.pdf`.
+
+### Output
+
+- PDFs are written to `dist/` (e.g., `dist/coleman-davis.pdf`).
+- A recap report is also written to `dist/<slug>.pdf-recap.md` so you can quickly review how the builder paginated and sectioned each CV.
+
+### Important notes
+
+- This environment may fail during Playwright Chromium download if external mirrors return 403.
+- Script-level parse/runtime checks can still be verified with `node --check scripts/build-cv-pdf.js`.
+- Set `CV_PDF_RECAP_ONLY=1` to generate only the recap file without invoking Vivliostyle (useful in restricted CI or local environments).
+
+---
+
+## Embeddable CV (`cv-embed.js`)
+
+A **non-iframe** embed that renders directly in the host page and isolates styles using **Shadow DOM**.
+
+### Basic snippet
+
+```html
+<div id="cv-embed-target"></div>
+<script
+  src="https://cpd4f.github.io/cv-builder/cv-embed.js"
+  data-cv="coleman-davis"
+  data-target="cv-embed-target"
+></script>
+```
+
+### Supported `data-*` attributes
+
+- `data-cv` (required): slug to load (`data/cv/<slug>.json`).
+- `data-target` (optional): target container ID.
+- `data-base-url` (optional): override base URL for self-hosting.
+
+### Embed docs page
+
+- `cv-embed.html` provides:
+  - Copy-to-clipboard snippet.
+  - Usage/options guidance.
+  - Live preview.
+
+---
+
+## AI Feedback Automation
+
+### Script (`scripts/run-cv-ai-feedback.js`)
+
+- Targets one triggering CV record (resolved from issue/body inputs).
+- Converts CV JSON/content into structured prompt text.
+- Calls OpenAI using `OPENAI_API_KEY`.
+- Writes response to Airtable field: `Overall AI Feedback`.
+- Then writes targeted CV-table feedback to `AI Feedback Intro`, `AI Feedback Core Competencies`, and `AI Feedback Footer` when those source blocks exist.
+- Finally (last step) generates **item-level** feedback for eligible CV Items and writes it to each item's `AI Feedback` field in the `CV Items` table (excluding `Education` and `Second Page Rail`).
+
+### Model
+
+- Configured for `gpt-5.4` per project requirement for overall, CV-table field, and item-level feedback generation.
+
+### Required environment
+
+- `AIRTABLE_PAT`
+- `AIRTABLE_BASE_ID`
+- `OPENAI_API_KEY`
+- Issue context (`ISSUE_TITLE`/`ISSUE_BODY`) when running issue-driven targeting.
+
+---
+
+## GitHub Actions: `cv-ai-feedback.yml`
+
+Workflow triggers:
+
+- `workflow_dispatch`
+- `issues` events: opened / edited / reopened
+
+Behavior:
+
+1. Validates guard conditions for issue-triggered runs (title prefix + expected author).
+2. Installs dependencies.
+3. Runs `npm run ai:feedback`.
+4. Posts success/failure comment back to the triggering issue.
+
+---
+
+## Local Development Checklist
+
+1. `npm install`
+2. Configure `.env` (or export shell vars) for Airtable/OpenAI secrets.
+3. `npm run build:json`
+4. `npm run pdf:build`
+5. Serve repository root with any static server and test:
+   - `/cv?cv=coleman-davis`
+   - `/cv-print.html?cv=coleman-davis`
+   - `/cv-feedback.html?cv=coleman-davis`
+   - `/cv-embed.html`
+
+---
+
+## Troubleshooting
+
+### `npm run pdf:build` fails with Playwright download 403
+
+This is typically an environment/network limitation when Vivliostyle tries to fetch Chromium. Re-run in an environment with Playwright download access or preinstalled browser binaries.
+
+### Missing footer content
+
+Confirm the source Airtable field is `CV_Footer` on the `CVs` table and rerun `npm run build:json`. Footer content is optional and only renders when present.
+
+### Triggered workflow ran but nothing updated
+
+- Check issue title/body includes valid record ID (`rec...`).
+- Confirm secrets are available to workflow (`AIRTABLE_PAT`, `AIRTABLE_BASE_ID`, `OPENAI_API_KEY`).
+- Review workflow logs and issue comments for guard/failure reasons.
+
+---
+
+## Deployment Notes
+
+This repo is designed for static hosting (e.g., GitHub Pages). Ensure the following are published:
+
+- `data/cv/*.json`
+- `dist/*.pdf`
+- `cv.html`, `cv-print.html`, `cv-embed.html`, `cv-embed.js`, `cv-render.js`, `cv-print.css`

--- a/cv-embed.html
+++ b/cv-embed.html
@@ -1,0 +1,109 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>CV Embed Instructions</title>
+    <style>
+      body {
+        margin: 0;
+        padding: 24px;
+        font-family: Inter, "Segoe UI", Roboto, Arial, sans-serif;
+        background: #f4f6f8;
+        color: #111827;
+        line-height: 1.45;
+      }
+      .wrap {
+        max-width: 980px;
+        margin: 0 auto;
+      }
+      h1 { margin: 0 0 8px; }
+      p { margin: 0 0 16px; }
+      .card {
+        background: #fff;
+        border: 1px solid #d6dbe2;
+        border-radius: 10px;
+        padding: 16px;
+        margin-bottom: 16px;
+      }
+      pre {
+        margin: 0;
+        overflow: auto;
+        padding: 12px;
+        border-radius: 8px;
+        background: #0f172a;
+        color: #e2e8f0;
+      }
+      code { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+      #embed-host { min-height: 600px; }
+      #copy-snippet {
+        border: 0;
+        border-radius: 999px;
+        background: #1f2937;
+        color: #fff;
+        padding: 8px 14px;
+        font-size: 13px;
+        font-weight: 600;
+        cursor: pointer;
+      }
+      #copy-snippet:hover { background: #111827; }
+      #copy-status { margin-left: 8px; font-size: 13px; color: #1f2937; }
+    </style>
+  </head>
+  <body>
+    <div class="wrap">
+      <h1>Embed this CV on any external site</h1>
+      <p>
+        This embed is now <strong>non-iframe</strong>: it renders directly in the page, is responsive,
+        and is isolated from host-site CSS using <strong>Shadow DOM</strong>.
+      </p>
+
+      <section class="card">
+        <h2>Copy/paste snippet</h2>
+        <p><button id="copy-snippet" type="button">Copy embed code</button> <span id="copy-status" aria-live="polite"></span></p>
+        <pre><code id="embed-snippet">&lt;div id="cv-embed-target"&gt;&lt;/div&gt;
+&lt;script
+  src="https://cpd4f.github.io/cv-builder/cv-embed.js"
+  data-cv="coleman-davis"
+  data-target="cv-embed-target"
+&gt;&lt;/script&gt;</code></pre>
+      </section>
+
+      <section class="card">
+        <h2>Options</h2>
+        <ul>
+          <li><code>data-cv</code> (required): CV slug, e.g. <code>coleman-davis</code>.</li>
+          <li><code>data-target</code> (optional): container element id where the embed should render.</li>
+          <li><code>data-base-url</code> (optional): override base URL if you self-host files.</li>
+        </ul>
+      </section>
+
+      <section class="card">
+        <h2>Live preview</h2>
+        <div id="embed-host"></div>
+        <script
+          src="./cv-embed.js"
+          data-cv="coleman-davis"
+          data-target="embed-host"
+        ></script>
+      </section>
+    </div>
+  
+    <script>
+      const copyBtn = document.getElementById("copy-snippet");
+      const copyStatus = document.getElementById("copy-status");
+      const snippetEl = document.getElementById("embed-snippet");
+      if (copyBtn && snippetEl) {
+        copyBtn.addEventListener("click", async () => {
+          try {
+            await navigator.clipboard.writeText(snippetEl.textContent);
+            if (copyStatus) copyStatus.textContent = "Copied!";
+          } catch (error) {
+            if (copyStatus) copyStatus.textContent = "Copy failed. Please copy manually.";
+          }
+          setTimeout(() => { if (copyStatus) copyStatus.textContent = ""; }, 1800);
+        });
+      }
+    </script>
+</body>
+</html>

--- a/cv-embed.js
+++ b/cv-embed.js
@@ -1,0 +1,324 @@
+(function () {
+  function escapeHtml(value) {
+    return String(value || "")
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/\"/g, "&quot;")
+      .replace(/'/g, "&#39;");
+  }
+
+  function key(value) {
+    return String(value || "").trim().toLowerCase();
+  }
+
+  function parseDateValue(value) {
+    if (!value) return Number.NEGATIVE_INFINITY;
+    const timestamp = Date.parse(String(value));
+    return Number.isNaN(timestamp) ? Number.NEGATIVE_INFINITY : timestamp;
+  }
+
+  function sortItems(items) {
+    return [...items].sort((a, b) => {
+      const aManual = String(a.manualsort || "").trim();
+      const bManual = String(b.manualsort || "").trim();
+      if (aManual && bManual && aManual !== bManual) return aManual.localeCompare(bManual, undefined, { numeric: true, sensitivity: "base" });
+      if (aManual && !bManual) return -1;
+      if (!aManual && bManual) return 1;
+      const byStart = parseDateValue(b.start) - parseDateValue(a.start);
+      if (byStart !== 0) return byStart;
+      return parseDateValue(b.end) - parseDateValue(a.end);
+    });
+  }
+
+
+
+  function inlineMarkdownToHtml(text) {
+    const escaped = escapeHtml(text);
+    return escaped
+      .replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>")
+      .replace(/\*(.+?)\*/g, "<em>$1</em>")
+      .replace(/`(.+?)`/g, "<code>$1</code>")
+      .replace(/\[(.+?)\]\((https?:[^\s)]+)\)/g, '<a href="$2" target="_blank" rel="noopener noreferrer">$1</a>');
+  }
+
+  function markdownToHtml(markdown) {
+    const raw = String(markdown || "").trim();
+    if (!raw) return "";
+    const lines = raw.split(/\r?\n/);
+    const chunks = [];
+    let list = [];
+    const flush = function () {
+      if (!list.length) return;
+      chunks.push("<ul>" + list.map(function (x) { return "<li>" + inlineMarkdownToHtml(x) + "</li>"; }).join("") + "</ul>");
+      list = [];
+    };
+
+    lines.forEach(function (line) {
+      const t = line.trim();
+      const bullet = t.match(/^[-*]\s+(.*)$/);
+      if (bullet) {
+        list.push(bullet[1]);
+        return;
+      }
+      flush();
+      const heading = t.match(/^(#{1,6})\s+(.*)$/);
+      if (heading) {
+        const level = Math.min(6, heading[1].length);
+        chunks.push("<h" + level + ">" + inlineMarkdownToHtml(heading[2]) + "</h" + level + ">");
+        return;
+      }
+      if (t) chunks.push("<p>" + inlineMarkdownToHtml(t) + "</p>");
+    });
+    flush();
+    return chunks.join("\n");
+  }
+
+  function formatApDate(value) {
+    const input = String(value || "").trim();
+    if (!input) return "";
+    const date = new Date(input);
+    if (Number.isNaN(date.getTime())) return input;
+    const months = ["Jan.", "Feb.", "Mar.", "Apr.", "May", "Jun.", "Jul.", "Aug.", "Sep.", "Oct.", "Nov.", "Dec."];
+    return months[date.getMonth()] + " " + date.getFullYear();
+  }
+
+  function displayDate(item) {
+    if (item.dispdate) return String(item.dispdate);
+    const start = formatApDate(item.start);
+    const end = formatApDate(item.end);
+    if (start && end) return start + " – " + end;
+    if (start) return "Since " + start;
+    return end;
+  }
+
+  function renderEntry(item) {
+    const meta = [item.subtitle, item.location].filter(Boolean).map(escapeHtml).join(" • ");
+    const date = displayDate(item);
+    const titleHtml = item.title ? '<h4 class="entry-title">' + escapeHtml(item.title) + "</h4>" : "";
+    const metaHtml = meta ? '<div class="entry-meta">' + meta + "</div>" : "";
+    const dateHtml = date ? '<div class="entry-date">' + escapeHtml(date) + "</div>" : "";
+    const contentHtml = item.content ? '<div class="entry-content">' + markdownToHtml(item.content) + "</div>" : "";
+    return '<article class="entry">' + titleHtml + metaHtml + dateHtml + contentHtml + "</article>";
+  }
+
+  function sectionHtml(title, items, hideEntryTitleWhenSameAsSection) {
+    if (!items.length) return "";
+    const normalizedTitle = key(title);
+    const entries = sortItems(items).map(function (item) {
+      if (hideEntryTitleWhenSameAsSection && key(item.title) === normalizedTitle) {
+        return renderEntry({ ...item, title: "" });
+      }
+      return renderEntry(item);
+    }).join("\n");
+    return '<section class="section"><h3>' + escapeHtml(title) + "</h3>" + entries + "</section>";
+  }
+
+
+  function titledItemsAsSectionsHtml(items) {
+    return sortItems(items).map(function (item) {
+      if (!item?.title) return "";
+      return '<section class="section"><h3>' + escapeHtml(item.title) + "</h3>" + renderEntry({ ...item, title: "" }) + "</section>";
+    }).join("\n");
+  }
+
+  function footerHtml(items) {
+    return sortItems(items).map(function (item) {
+      return renderEntry({ ...item, title: "" });
+    }).join("\n");
+  }
+
+  function renderFooterContentHtml(techItems, footerItems) {
+    const parts = [];
+    const tech = sortItems(techItems || []);
+    if (tech.length) {
+      parts.push('<section class="section footer-tech"><h3>Technical + IT</h3><div class="tech-grid">');
+      tech.forEach(function (item) {
+        parts.push(renderEntry(item));
+      });
+      parts.push('</div></section>');
+    }
+    const footer = sortItems(footerItems || []);
+    if (footer.length) {
+      parts.push('<section class="section footer-block">');
+      footer.forEach(function (item) {
+        parts.push(renderEntry({ ...item, title: "" }));
+      });
+      parts.push('</section>');
+    }
+    return parts.join("\n");
+  }
+
+  function groupBySection(items) {
+    const grouped = new Map();
+    (Array.isArray(items) ? items : []).forEach(function (item) {
+      const section = key(item.section);
+      if (!section || section === "header" || section === "contact") return;
+      if (!grouped.has(section)) grouped.set(section, []);
+      grouped.get(section).push(item);
+    });
+    return grouped;
+  }
+
+  function iconClassForContact(text) {
+    const v = String(text || "").toLowerCase();
+    if (v.includes("@")) return "fa-solid fa-envelope";
+    if (v.includes("http") || v.includes("www.")) return "fa-solid fa-globe";
+    if (/[+()\d\s-]{7,}/.test(v)) return "fa-solid fa-phone";
+    return "fa-solid fa-address-card";
+  }
+
+  const scripts = document.querySelectorAll('script[src*="cv-embed.js"]');
+  const scriptEl = scripts[scripts.length - 1];
+  if (!scriptEl) return;
+
+  const slug = (scriptEl.dataset.cv || "").trim().toLowerCase();
+  if (!slug) {
+    console.error('[cv-embed] Missing required data-cv attribute on cv-embed.js script tag.');
+    return;
+  }
+
+  const baseUrl = (scriptEl.dataset.baseUrl || scriptEl.src).replace(/\/cv-embed\.js(?:\?.*)?$/, "").replace(/\/$/, "");
+  const targetId = scriptEl.dataset.target || "";
+  const host = targetId ? document.getElementById(targetId) : null;
+  const mount = host || document.createElement("div");
+  if (!host) scriptEl.insertAdjacentElement("afterend", mount);
+
+  const shadow = mount.attachShadow({ mode: "open" });
+  shadow.innerHTML = `
+    <style>
+      :host, .cv-embed-shell, .cv-embed-shell * { box-sizing: border-box; }
+      .cv-embed-shell {
+        --bg: #ffffff;
+        --text: #000000;
+        --muted: #3d4248;
+        --panel: #2c3237;
+        --panel-text: #f7f9fb;
+        --rule: #dadde0;
+        color: var(--text);
+        font-family: Inter, "Segoe UI", Roboto, Arial, sans-serif;
+        line-height: 1.35;
+        font-size: 11pt;
+        width: 100%;
+      }
+      .cv-embed-page {
+        width: 100%;
+        background: #fff;
+        border: 1px solid #d8dde3;
+        border-radius: 4px;
+        overflow: hidden;
+      }
+      .header { padding: 22mm 16mm 8mm; border-bottom: 1px solid var(--rule); }
+      .header h1 { margin: 0; font-size: 28pt; font-weight: 800; letter-spacing: 0.02em; }
+      .header h2 { margin: 2mm 0 0; font-size: 14pt; font-weight: 500; }
+      .header-summary { margin-top: 5mm; font-size: 11pt; line-height: 1.45; }
+      .contact-bar {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(120px, 1fr));
+        background: var(--panel);
+        color: var(--panel-text);
+        padding: 18px 16mm;
+      }
+      .contact-item {
+        padding: 8px 0;
+        font-size: 11pt;
+        overflow-wrap: anywhere;
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+      .contact-item i { width: 14px; text-align: center; }
+      .contact-item:first-child { padding-right: 16px; }
+      .contact-item:last-child { padding-left: 16px; }
+      .content {
+        display: grid;
+        grid-template-columns: 1.55fr 0.75fr;
+        gap: 12mm;
+        padding: 12mm 16mm 16mm;
+      }
+      .footer { grid-column: 1 / -1; }
+      .tech-grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 12px; }
+      .tech-grid .entry { margin-bottom: 0; }
+      .footer-block { margin-top: 12px; }
+      .section { margin-bottom: 22px; }
+      .section h3 { margin: 0 0 8px; font-size: 13pt; font-weight: 700; }
+      .entry { margin-bottom: 16px; }
+      .entry-title { margin: 0; font-size: 12pt; font-weight: 700; }
+      .entry-meta { margin: 2px 0 0; font-size: 11.5pt; font-weight: 500; }
+      .entry-date { margin-top: 4px; font-size: 10.5pt; color: var(--muted); }
+      .entry-content { margin-top: 8px; font-size: 11pt; line-height: 1.45; }
+      .entry-content p { margin: 0 0 8px; }
+      .entry-content ul, .entry-content ol { margin: 0; padding-left: 0; list-style: none; }
+      .entry-content li { margin: 0 0 5px; padding-left: 12px; position: relative; }
+      .entry-content li::before { content: "•"; position: absolute; left: 0; }
+      .cv-embed-error {
+        background: #fceaea;
+        border: 1px solid #f0c5c5;
+        color: #8b1111;
+        border-radius: 8px;
+        padding: 12px;
+      }
+      @media (max-width: 920px) {
+        .content { grid-template-columns: 1fr; gap: 6mm; }
+        .contact-bar { grid-template-columns: 1fr; }
+        .contact-item { padding-left: 0; }
+        .contact-item:last-child { padding-left: 0; }
+        .tech-grid { grid-template-columns: 1fr; }
+      }
+    </style>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <div class="cv-embed-shell">
+      <main class="cv-embed-page">
+        <header class="header" id="header"></header>
+        <section class="contact-bar" id="contact"></section>
+        <section class="content">
+          <div id="main-col"></div>
+          <div id="rail-col"></div>
+          <div class="footer" id="footer-col"></div>
+        </section>
+      </main>
+    </div>
+  `;
+
+  fetch(baseUrl + "/data/cv/" + encodeURIComponent(slug) + ".json", { cache: "no-store" })
+    .then(function (response) {
+      if (!response.ok) throw new Error("Unable to load CV data for slug \"" + slug + "\" (HTTP " + response.status + ")");
+      return response.json();
+    })
+    .then(function (cv) {
+      const items = Array.isArray(cv.items) ? cv.items : [];
+      const grouped = groupBySection(items);
+      const header = items.find(function (item) { return key(item.section) === "header"; }) || {};
+      const contacts = items.filter(function (item) { return key(item.section) === "contact" && String(item.content || "").trim() !== ""; });
+
+      shadow.getElementById("header").innerHTML =
+        "<h1>" + escapeHtml(header.title || "CV") + "</h1>" +
+        "<h2>" + escapeHtml(header.subtitle || "") + "</h2>" +
+        '<div class="header-summary">' + markdownToHtml(header.content || "") + "</div>";
+
+      shadow.getElementById("contact").innerHTML = contacts
+        .map(function (item) {
+          return '<div class="contact-item"><i class="' + iconClassForContact(item.content) + '" aria-hidden="true"></i><span>' + escapeHtml(item.content) + "</span></div>";
+        })
+        .join("");
+
+      const mainCol = shadow.getElementById("main-col");
+      const railCol = shadow.getElementById("rail-col");
+      const footerCol = shadow.getElementById("footer-col");
+
+      mainCol.innerHTML =
+        sectionHtml("Core Competencies", grouped.get("core competencies") || [], true) +
+        sectionHtml("Work Experience", grouped.get("work experience") || [], false);
+
+      railCol.innerHTML =
+        sectionHtml("Skills", grouped.get("topline skills") || [], false) +
+        sectionHtml("Education", grouped.get("education") || [], false) +
+        titledItemsAsSectionsHtml(grouped.get("second page rail") || []);
+
+      footerCol.innerHTML = renderFooterContentHtml(grouped.get("technical + it") || [], grouped.get("footer") || []);
+    })
+    .catch(function (error) {
+      const page = shadow.querySelector(".cv-embed-page");
+      page.innerHTML = '<div class="cv-embed-error">' + escapeHtml(error.message) + "</div>";
+    });
+})();

--- a/cv-feedback.html
+++ b/cv-feedback.html
@@ -1,0 +1,313 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>CV Feedback</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap" rel="stylesheet" />
+  <style>
+    :root {
+      --md-bg: #f5f6fa;
+      --md-surface: #ffffff;
+      --md-surface-2: #f8f9fd;
+      --md-text: #1f2937;
+      --md-muted: #6b7280;
+      --md-primary: #2563eb;
+      --md-outline: #e5e7eb;
+      --md-shadow: 0 1px 2px rgba(15, 23, 42, 0.08), 0 8px 24px rgba(15, 23, 42, 0.06);
+      --radius: 16px;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: Roboto, system-ui, -apple-system, Segoe UI, Arial, sans-serif;
+      background: linear-gradient(180deg, #f8f9ff 0%, var(--md-bg) 100%);
+      color: var(--md-text);
+      min-height: 100vh;
+    }
+    .container {
+      max-width: 1200px;
+      margin: 0 auto;
+      padding: 24px 16px 32px;
+    }
+    .toolbar {
+      display: flex;
+      gap: 12px;
+      align-items: center;
+      margin-bottom: 16px;
+      flex-wrap: wrap;
+    }
+    .toolbar label { font-weight: 500; color: var(--md-muted); }
+    .toolbar input {
+      min-width: 240px;
+      border: 1px solid var(--md-outline);
+      background: var(--md-surface);
+      border-radius: 12px;
+      padding: 10px 12px;
+      font-size: 14px;
+      box-shadow: 0 1px 0 rgba(15,23,42,.02);
+    }
+    .toolbar button {
+      border: 0;
+      background: var(--md-primary);
+      color: #fff;
+      border-radius: 999px;
+      padding: 10px 16px;
+      font-weight: 600;
+      cursor: pointer;
+      box-shadow: 0 4px 10px rgba(37, 99, 235, 0.3);
+    }
+    .toolbar button:hover { filter: brightness(0.97); }
+
+    .card {
+      background: var(--md-surface);
+      border: 1px solid var(--md-outline);
+      border-radius: var(--radius);
+      box-shadow: var(--md-shadow);
+    }
+
+    .overall {
+      padding: 20px;
+      margin-bottom: 16px;
+    }
+    .overall h1 {
+      margin: 0 0 12px;
+      font-size: 34px;
+      line-height: 1.1;
+      letter-spacing: -0.01em;
+      font-weight: 700;
+    }
+
+    .rows { display: grid; gap: 12px; }
+
+    .row {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 12px;
+      align-items: start;
+    }
+
+    .item-card,
+    .feedback-card { padding: 16px; }
+
+    .section-chip {
+      display: inline-flex;
+      border-radius: 999px;
+      border: 1px solid #dbe2f1;
+      background: #eef3ff;
+      color: #3858a6;
+      font-size: 11px;
+      font-weight: 600;
+      letter-spacing: .04em;
+      text-transform: uppercase;
+      padding: 4px 10px;
+      margin-bottom: 10px;
+    }
+
+    .item-title { margin: 0 0 4px; font-size: 21px; line-height: 1.2; }
+    .meta { color: var(--md-muted); margin-bottom: 8px; font-size: 14px; }
+
+    .feedback-card {
+      background: var(--md-surface-2);
+      border-color: #e1e6f3;
+      position: sticky;
+      top: 10px;
+    }
+    .feedback-title { margin: 0 0 8px; font-size: 17px; font-weight: 600; }
+
+    .md p { margin: 0 0 8px; line-height: 1.48; }
+    .md ul, .md ol { margin: 0 0 8px; padding-left: 22px; }
+    .md li { margin-bottom: 4px; line-height: 1.45; }
+    .md h2, .md h3, .md h4 { margin: 10px 0 6px; line-height: 1.3; }
+    .empty { color: var(--md-muted); font-style: italic; }
+    .error { color: #b91c1c; margin-top: 12px; }
+
+    @media (max-width: 980px) {
+      .row { grid-template-columns: 1fr; }
+      .feedback-card { position: static; }
+      .overall h1 { font-size: 28px; }
+    }
+  </style>
+</head>
+<body>
+  <main class="container">
+    <div class="toolbar">
+      <label for="slug">CV slug</label>
+      <input id="slug" placeholder="coleman-davis" />
+      <button id="load" type="button">Load</button>
+    </div>
+
+    <section class="card overall">
+      <h1>Overall feedback</h1>
+      <div id="overall" class="md">Loading…</div>
+    </section>
+
+    <section id="rows" class="rows"></section>
+    <p id="status" class="error"></p>
+  </main>
+
+  <script>
+    function escapeHtml(input) {
+      return String(input ?? "")
+        .replaceAll("&", "&amp;")
+        .replaceAll("<", "&lt;")
+        .replaceAll(">", "&gt;")
+        .replaceAll('"', "&quot;")
+        .replaceAll("'", "&#39;");
+    }
+
+    function inlineMarkdownToHtml(input) {
+      const escaped = escapeHtml(input);
+      return escaped
+        .replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>")
+        .replace(/\*(.+?)\*/g, "<em>$1</em>")
+        .replace(/`(.+?)`/g, "<code>$1</code>");
+    }
+
+    function markdownToHtml(input) {
+      const text = String(input || "").replace(/\r/g, "");
+      if (!text.trim()) return "";
+      const lines = text.split("\n");
+      const out = [];
+      let listType = null;
+
+      function closeList() {
+        if (!listType) return;
+        out.push(listType === "ol" ? "</ol>" : "</ul>");
+        listType = null;
+      }
+
+      for (const rawLine of lines) {
+        const line = rawLine.trim();
+        if (!line) { closeList(); continue; }
+
+        if (line.startsWith("## ")) { closeList(); out.push(`<h3>${inlineMarkdownToHtml(line.slice(3))}</h3>`); continue; }
+        if (line.startsWith("### ")) { closeList(); out.push(`<h4>${inlineMarkdownToHtml(line.slice(4))}</h4>`); continue; }
+
+        if (/^\d+[.)]\s+/.test(line)) {
+          if (listType !== "ol") { closeList(); out.push("<ol>"); listType = "ol"; }
+          out.push(`<li>${inlineMarkdownToHtml(line.replace(/^\d+[.)]\s+/, ""))}</li>`);
+          continue;
+        }
+
+        if (/^[-*]\s+/.test(line)) {
+          if (listType !== "ul") { closeList(); out.push("<ul>"); listType = "ul"; }
+          out.push(`<li>${inlineMarkdownToHtml(line.replace(/^[-*]\s+/, ""))}</li>`);
+          continue;
+        }
+
+        closeList();
+        out.push(`<p>${inlineMarkdownToHtml(line)}</p>`);
+      }
+
+      closeList();
+      return out.join("\n");
+    }
+
+    function displayDate(item) {
+      if (item?.dispdate) return item.dispdate;
+      const start = item?.start || "";
+      const end = item?.end || "Present";
+      if (!start) return "";
+      return `${start} – ${end}`;
+    }
+
+    function feedbackForItem(item, feedbackObj) {
+      const section = String(item?.section || "").toLowerCase();
+      if (item?.aiFeedback) return item.aiFeedback;
+      if (section === "header") return feedbackObj?.intro || "";
+      if (section === "core competencies") return feedbackObj?.coreCompetencies || "";
+      if (section === "footer") return feedbackObj?.footer || "";
+      return "";
+    }
+
+
+    function orderedItems(items) {
+      const order = new Map([
+        ["header", 0],
+        ["core competencies", 1],
+        ["work experience", 2],
+        ["topline skills", 3],
+        ["technical + it", 4],
+        ["education", 5],
+        ["second page rail", 5],
+        ["footer", 6]
+      ]);
+      return (items || [])
+        .map((item, index) => ({ item, index, rank: order.has(String(item?.section || "").toLowerCase()) ? order.get(String(item?.section || "").toLowerCase()) : 99 }))
+        .filter(({ item }) => String(item?.section || "").toLowerCase() !== "contact")
+        .sort((a, b) => a.rank - b.rank || a.index - b.index)
+        .map(({ item }) => item);
+    }
+
+    function renderItem(item, feedbackObj) {
+      const row = document.createElement("article");
+      row.className = "row";
+
+      const left = document.createElement("div");
+      left.className = "card item-card";
+      const metaBits = [item?.subtitle, item?.location, displayDate(item)].filter(Boolean);
+      left.innerHTML = `
+        <div class="section-chip">${escapeHtml(item?.section || "")}</div>
+        ${item?.title ? `<h2 class="item-title">${escapeHtml(item.title)}</h2>` : ""}
+        ${metaBits.length ? `<div class="meta">${escapeHtml(metaBits.join(" • "))}</div>` : ""}
+        <div class="md">${markdownToHtml(item?.content || "")}</div>
+      `;
+
+      const right = document.createElement("div");
+      right.className = "card feedback-card";
+      const feedback = feedbackForItem(item, feedbackObj);
+      right.innerHTML = `
+        <h3 class="feedback-title">Item feedback</h3>
+        <div class="md">${feedback ? markdownToHtml(feedback) : '<p class="empty">No item feedback available.</p>'}</div>
+      `;
+
+      row.append(left, right);
+      return row;
+    }
+
+    async function loadCv(slug) {
+      const overall = document.getElementById("overall");
+      const rows = document.getElementById("rows");
+      const status = document.getElementById("status");
+      status.textContent = "";
+      overall.textContent = "Loading…";
+      rows.innerHTML = "";
+
+      try {
+        const res = await fetch(`./data/cv/${encodeURIComponent(slug)}.json`, { cache: "no-store" });
+        if (!res.ok) throw new Error(`Unable to load CV (${res.status})`);
+        const cv = await res.json();
+        const feedback = cv?.feedback || {};
+
+        overall.innerHTML = feedback?.overall
+          ? markdownToHtml(feedback.overall)
+          : '<p class="empty">No overall feedback available.</p>';
+
+        const items = orderedItems(Array.isArray(cv?.items) ? cv.items : []);
+        items.forEach((item) => rows.appendChild(renderItem(item, feedback)));
+      } catch (error) {
+        overall.innerHTML = '<p class="empty">No overall feedback available.</p>';
+        status.textContent = error?.message || String(error);
+      }
+    }
+
+    const params = new URLSearchParams(location.search);
+    const slugInput = document.getElementById("slug");
+    const initialSlug = params.get("cv") || "coleman-davis";
+    slugInput.value = initialSlug;
+
+    document.getElementById("load").addEventListener("click", () => {
+      const slug = slugInput.value.trim() || "coleman-davis";
+      const next = new URL(location.href);
+      next.searchParams.set("cv", slug);
+      history.replaceState(null, "", next);
+      loadCv(slug);
+    });
+
+    loadCv(initialSlug);
+  </script>
+</body>
+</html>

--- a/cv-print.css
+++ b/cv-print.css
@@ -14,22 +14,14 @@
   margin: var(--page-margin);
 }
 
-@page :left {
-  margin-top: var(--page-margin);
-}
-
-@page :right {
-  margin-top: var(--page-margin);
-}
-
 html,
 body {
   margin: 0;
   padding: 0;
   font-family: "Segoe UI", Helvetica, Arial, sans-serif;
-  color: var(--text);
   font-size: 12px;
   line-height: 1.35;
+  color: var(--text);
   -webkit-print-color-adjust: exact;
   print-color-adjust: exact;
 }
@@ -38,9 +30,63 @@ body {
   width: 100%;
 }
 
+.cv-print.compact {
+  font-size: 11.75px;
+}
+
+.full-container {
+  display: grid;
+  grid-template-columns: minmax(0, 2.05fr) minmax(0, 0.95fr);
+  column-gap: 7mm;
+  width: 100%;
+}
+
+.header-container {
+  grid-column: 1 / span 2;
+  grid-row: 1 / span 1;
+  padding-bottom: 7mm;
+}
+
+.rail-page-1 {
+  grid-column: 2 / span 1;
+  grid-row: 2 / span 1;
+}
+
+.main-content-1 {
+  grid-column: 1 / span 1;
+  grid-row: 2 / span 1;
+}
+
+.rail-page-2 {
+  grid-column: 2 / span 1;
+  grid-row: 3 / span 1;
+}
+
+.main-content-2 {
+  grid-column: 1 / span 1;
+  grid-row: 3 / span 1;
+}
+
+.footer {
+  grid-column: 1 / span 2;
+  grid-row: 4 / span 1;
+  margin-top: 5mm;
+}
+
+
+.print-page {
+  break-after: page;
+  page-break-after: always;
+}
+
+.print-page:last-child {
+  break-after: auto;
+  page-break-after: auto;
+}
+
 .header {
   padding: 0 0 5mm;
-  border-bottom: 1px solid var(--rule);
+  border-bottom: 0;
   break-inside: avoid;
 }
 
@@ -55,7 +101,7 @@ body {
 .header h2 {
   margin: 2mm 0 0;
   font-size: 15px;
-  font-weight: 600;
+  font-weight: 700;
 }
 
 .header-summary {
@@ -69,30 +115,35 @@ body {
 .contact-bar {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
+  margin: 0 calc(-1 * var(--page-margin));
+  padding: 4mm var(--page-margin);
   background: var(--panel);
   color: var(--panel-text);
-  margin: 0 calc(-1 * var(--page-margin));
-  padding: 3mm var(--page-margin);
 }
 
 .contact-item {
+  padding: 0 8px;
   font-size: 9px;
   font-weight: 600;
   border-right: 1px solid #4b555f;
-  padding: 0 8px;
   overflow-wrap: anywhere;
+  display: flex;
+  align-items: center;
+  gap: 6px;
 }
 
+.contact-item i { width: 10px; text-align: center; }
+
 .contact-item:first-child { padding-left: 0; }
-.contact-item:last-child { border-right: 0; padding-right: 0; }
+.contact-item:last-child { padding-right: 0; border-right: 0; }
 
 .content {
-  margin-top: 6mm;
+  margin-top: 0;
   width: 100%;
-  display: grid;
-  grid-template-columns: minmax(0, 1.95fr) minmax(0, 1fr);
-  column-gap: 6mm;
-  align-items: start;
+}
+
+.print-page.first .content {
+  margin-top: 6mm;
 }
 
 .main-col,
@@ -100,26 +151,11 @@ body {
   min-width: 0;
 }
 
-.main-col {
-  float: left;
-  width: 64%;
-}
-
-.rail-col {
-  float: right;
-  width: 32%;
-}
-
 .section {
   margin-bottom: 10px;
-}
-
-.content > .main-col > .section,
-.content > .rail-col > .section {
   break-inside: auto;
   page-break-inside: auto;
 }
-
 
 .section h3 {
   margin: 0 0 6px;
@@ -142,23 +178,26 @@ body {
   font-weight: 700;
 }
 
+.entry-meta,
+.entry-date,
+.entry-content {
+  font-size: 12px;
+}
+
 .entry-meta {
   margin: 1px 0 0;
-  font-size: 12px;
   line-height: 1.25;
   font-weight: 600;
 }
 
 .entry-date {
   margin-top: 2px;
-  font-size: 12px;
   line-height: 1.2;
   color: var(--muted);
 }
 
 .entry-content {
   margin-top: 4px;
-  font-size: 12px;
   line-height: 1.28;
 }
 
@@ -182,25 +221,27 @@ body {
   left: 0;
 }
 
-.rail-col .section h3 { font-size: 13px; }
+.rail-col .section h3,
 .rail-col .entry-title { font-size: 13px; }
-.rail-col .entry-meta,
-.rail-col .entry-date,
-.rail-col .entry-content { font-size: 12px; }
 
+.skills-section .entry { margin-bottom: 2px; }
+.skills-section .entry-content { margin-top: 0; }
 
-.skills-section .entry {
-  margin-bottom: 2px;
+.tech-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
 }
 
-.skills-section .entry-content {
-  margin-top: 0;
+.tech-grid .entry {
+  margin-bottom: 0;
 }
 
-
-.print-actions {
-  display: none;
+.footer-block {
+  margin-top: 8px;
 }
+
+.print-actions { display: none; }
 
 .print-btn {
   border: 0;
@@ -238,29 +279,48 @@ body {
 
   .content {
     display: grid;
-    grid-template-columns: minmax(0, 1.95fr) minmax(0, 1fr);
-    column-gap: 6mm;
+    grid-template-columns: minmax(0, 2.05fr) minmax(0, 0.95fr);
+    column-gap: 7mm;
     align-items: start;
   }
+}
 
-  .content::after {
-    content: none;
+@media print {
+  body {
+    margin: 0;
+    padding: 0;
+  }
+
+  .content {
+    display: grid;
+    grid-template-columns: minmax(0, 2.05fr) minmax(0, 0.95fr);
+    column-gap: 7mm;
+    align-items: start;
+    width: 100%;
+    break-inside: auto;
+    page-break-inside: auto;
   }
 
   .main-col,
   .rail-col {
     float: none;
     width: auto;
+    min-width: 0;
+    break-inside: auto;
+    page-break-inside: auto;
   }
 
-  .main-col { grid-column: 1; }
-  .rail-col { grid-column: 2; }
-}
+  .main-col { grid-column-start: 1; }
+  .rail-col { grid-column-start: 2; }
 
-@media print {
-  body {
-    padding: 0;
-    margin: 0;
+  .content-first .main-col-first {
+    grid-column-start: 1;
+    grid-row-start: 1;
+  }
+
+  .content-first .rail-col-first {
+    grid-column-start: 2;
+    grid-row-start: 1;
   }
 
   .print-actions {

--- a/cv-print.html
+++ b/cv-print.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>CV Print</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <link rel="stylesheet" href="cv-print.css" />
   </head>
   <body>
@@ -12,14 +13,7 @@
       <button class="print-btn" id="download-btn" type="button">Download PDF</button>
     </div>
 
-    <main class="cv-print" id="cv-print-root">
-      <header class="header" id="header"></header>
-      <section class="contact-bar" id="contact"></section>
-      <section class="content">
-        <div class="main-col" id="main-col"></div>
-        <aside class="rail-col" id="rail-col"></aside>
-      </section>
-    </main>
+    <main class="cv-print" id="cv-print-root"></main>
 
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
     <script src="cv-render.js"></script>
@@ -29,12 +23,8 @@
       const injectedSlug = String(window.__CV_SLUG__ || "").trim().toLowerCase();
       const slug = (query.get("cv") || injectedSlug || pathSlug || location.hash.replace(/^#/, "") || "coleman-davis").trim().toLowerCase();
 
-
       async function loadCvData() {
-        if (window.__CV_DATA__ && typeof window.__CV_DATA__ === "object") {
-          return window.__CV_DATA__;
-        }
-
+        if (window.__CV_DATA__ && typeof window.__CV_DATA__ === "object") return window.__CV_DATA__;
         const response = await fetch(`data/cv/${encodeURIComponent(slug)}.json`, { cache: "no-store" });
         if (!response.ok) throw new Error(`Unable to load data/cv/${slug}.json (HTTP ${response.status})`);
         return response.json();
@@ -43,16 +33,7 @@
       async function init() {
         try {
           const cv = await loadCvData();
-          const items = Array.isArray(cv.items) ? cv.items : [];
-
-          const header = items.find((item) => window.CvRender.key(item.section) === "header") || {};
-          const contacts = items.filter((item) => window.CvRender.key(item.section) === "contact");
-          const mainHost = document.getElementById("main-col");
-          const railHost = document.getElementById("rail-col");
-
-          window.CvRender.renderHeader(document.getElementById("header"), header);
-          window.CvRender.renderContact(document.getElementById("contact"), contacts, false);
-          window.CvRender.renderColumns(items, mainHost, railHost);
+          window.CvRender.renderPaginatedCv(document.getElementById("cv-print-root"), cv);
         } catch (error) {
           document.body.innerHTML = `<div style="padding:20px;color:#8b1111">${error.message}</div>`;
         }
@@ -63,11 +44,7 @@
       }
 
       async function downloadPdfForSlug(slugValue) {
-        const candidates = [
-          `dist/${encodeURIComponent(slugValue)}.pdf`,
-          `./dist/${encodeURIComponent(slugValue)}.pdf`
-        ];
-
+        const candidates = [`dist/${encodeURIComponent(slugValue)}.pdf`, `./dist/${encodeURIComponent(slugValue)}.pdf`];
         try {
           let response = null;
           for (const path of candidates) {
@@ -87,7 +64,7 @@
           anchor.click();
           anchor.remove();
           URL.revokeObjectURL(url);
-        } catch (error) {
+        } catch (_) {
           alert("Prebuilt PDF not found on this environment. Opening print dialog so you can Save as PDF.");
           openPrintDialog();
         }

--- a/cv-render.js
+++ b/cv-render.js
@@ -1,7 +1,5 @@
 (function initCvRender(global) {
-  function key(value) {
-    return String(value || "").trim().toLowerCase();
-  }
+  function key(value) { return String(value || "").trim().toLowerCase(); }
 
   function parseDateValue(value) {
     if (!value) return Number.NEGATIVE_INFINITY;
@@ -13,26 +11,13 @@
     return [...items].sort((a, b) => {
       const aManual = String(a.manualsort || "").trim();
       const bManual = String(b.manualsort || "").trim();
-      if (aManual && bManual && aManual !== bManual) {
-        return aManual.localeCompare(bManual, undefined, { numeric: true, sensitivity: "base" });
-      }
+      if (aManual && bManual && aManual !== bManual) return aManual.localeCompare(bManual, undefined, { numeric: true, sensitivity: "base" });
       if (aManual && !bManual) return -1;
       if (!aManual && bManual) return 1;
-
       const byStart = parseDateValue(b.start) - parseDateValue(a.start);
       if (byStart !== 0) return byStart;
-      const byEnd = parseDateValue(b.end) - parseDateValue(a.end);
-      if (byEnd !== 0) return byEnd;
-      return 0;
+      return parseDateValue(b.end) - parseDateValue(a.end);
     });
-  }
-
-  function titleCase(value) {
-    return String(value || "")
-      .split(/\s+/)
-      .filter(Boolean)
-      .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-      .join(" ");
   }
 
   function markdownToHtml(markdown) {
@@ -60,114 +45,66 @@
     return end;
   }
 
-  function contactIconClass(title) {
-    const t = String(title || "").trim().toLowerCase();
-    if (t === "email") return "fa-solid fa-envelope";
-    if (t === "website") return "fa-solid fa-link";
-    if (t === "phone") return "fa-solid fa-phone";
-    return "fa-solid fa-circle-info";
+  function estimateUnits(item, isRail = false) {
+    const text = `${item.title || ""} ${item.subtitle || ""} ${item.location || ""} ${item.content || ""}`.trim();
+    const chars = text.length;
+    const perLine = isRail ? 52 : 68;
+    const lines = Math.max(1, Math.ceil(chars / perLine));
+    const base = isRail ? 0.9 : 1.2;
+    const contentPenalty = item.content ? (isRail ? 0.8 : 1.1) : 0;
+    return base + lines + contentPenalty;
   }
 
-  function renderHeader(host, item) {
-    host.innerHTML = `
-      <h1>${item?.title || "CV"}</h1>
-      <h2>${item?.subtitle || ""}</h2>
-      <div class="header-summary">${markdownToHtml(item?.content || "")}</div>
-    `;
+  function makeEntry(item, hideTitle) {
+    return { item, hideTitle, units: estimateUnits(item, false), type: "entry" };
   }
 
-  function renderContact(host, items, withIcons = true) {
-    const entries = items.filter((item) => String(item?.content || "").trim() !== "");
-    if (!entries.length) {
-      host.style.display = "none";
-      return;
-    }
-
-    host.style.display = "grid";
-    host.innerHTML = "";
-    entries.forEach((item) => {
-      const el = document.createElement("div");
-      el.className = "contact-item";
-      el.innerHTML = withIcons
-        ? `<i class="${contactIconClass(item.title)}" aria-hidden="true"></i><span>${item.content || ""}</span>`
-        : `<span>${item.content || ""}</span>`;
-      host.appendChild(el);
-    });
-  }
-
-  function renderEntry(item, options = {}) {
-    const wrap = document.createElement("article");
-    wrap.className = "entry";
-
-    const hideTitle = Boolean(options.hideEntryTitle);
-
-    if (item.title && !hideTitle) {
-      const title = document.createElement("h4");
-      title.className = "entry-title";
-      title.textContent = item.title;
-      wrap.appendChild(title);
-    }
-
-    if (item.subtitle || item.location) {
-      const meta = document.createElement("div");
-      meta.className = "entry-meta";
-      meta.textContent = [item.subtitle, item.location].filter(Boolean).join(" • ");
-      wrap.appendChild(meta);
-    }
-
-    if (item.start || item.end || item.dispdate) {
-      const date = document.createElement("div");
-      date.className = "entry-date";
-      date.textContent = displayDate(item);
-      wrap.appendChild(date);
-    }
-
-    if (item.content) {
-      const content = document.createElement("div");
-      content.className = "entry-content";
-      content.innerHTML = markdownToHtml(item.content);
-      wrap.appendChild(content);
-    }
-
-    return wrap;
-  }
-
-  function renderSection(host, title, items, options = {}) {
-    if (!items.length) return;
-    const section = document.createElement("section");
-    section.className = "section";
-
-    const normalizedTitle = String(title || "").trim().toLowerCase();
-    if (normalizedTitle === "skills") section.classList.add("skills-section");
-    section.innerHTML = `<h3>${title}</h3>`;
+  function sectionEntries(title, items, opts = {}) {
+    if (!items.length) return [];
+    const normalized = key(title);
+    const out = [];
+    if (!opts.hideSectionTitle) out.push({ type: "section-title", title, units: 0.5 });
     sortItems(items).forEach((item) => {
-      const itemTitle = String(item?.title || "").trim().toLowerCase();
-      const hideEntryTitle = options.hideEntryTitleWhenSameAsSection && itemTitle && itemTitle === normalizedTitle;
-      section.appendChild(renderEntry(item, { hideEntryTitle }));
+      const hideTitle = opts.hideAllEntryTitles || (opts.hideEntryTitleWhenSameAsSection && key(item.title) && key(item.title) === normalized);
+      out.push(makeEntry(item, hideTitle));
     });
-
-    host.appendChild(section);
+    return out;
   }
 
-  function renderSecondRail(host, items) {
-    sortItems(items).forEach((item) => {
-      if (!item.title) return;
-      const section = document.createElement("section");
-      section.className = "section";
-      section.innerHTML = `<h3>${item.title}</h3>`;
-      if (item.content) {
-        const body = document.createElement("div");
-        body.className = "entry-content";
-        body.innerHTML = markdownToHtml(item.content);
-        section.appendChild(body);
-      }
-      host.appendChild(section);
+  function sectionEntriesOrdered(title, items, opts = {}) {
+    if (!items.length) return [];
+    const normalized = key(title);
+    const out = [];
+    if (!opts.hideSectionTitle) out.push({ type: "section-title", title, units: 0.5 });
+    items.forEach((item) => {
+      const hideTitle = opts.hideAllEntryTitles || (opts.hideEntryTitleWhenSameAsSection && key(item.title) && key(item.title) === normalized);
+      out.push(makeEntry(item, hideTitle));
     });
+    return out;
+  }
+
+  function workAndTechEntries(workItems, techItems) {
+    const merged = [];
+    if (workItems.length || techItems.length) merged.push({ type: "section-title", title: "Work Experience", units: 0.5 });
+    sortItems(workItems).forEach((item) => merged.push(makeEntry(item, false)));
+    sortItems(techItems).forEach((item) => merged.push(makeEntry(item, false)));
+    return merged;
+  }
+
+  function splitSkillsBullets(items) {
+    const out = [];
+    for (const item of items) {
+      const lines = String(item?.content || "").split(/\r?\n/).map((l) => l.trim()).filter((l) => /^[-*]\s+/.test(l));
+      if (lines.length < 2) { out.push(item); continue; }
+      lines.forEach((line, index) => out.push({ ...item, title: "", subtitle: "", location: "", start: "", end: "", dispdate: "", manualsort: item.manualsort ? `${item.manualsort}.${String(index + 1).padStart(3, "0")}` : "", content: line }));
+    }
+    return out;
   }
 
   function groupBySection(items) {
     const grouped = new Map();
-    items.forEach((item) => {
+    const source = Array.isArray(items) ? items : [];
+    source.forEach((item) => {
       const section = key(item.section);
       if (!section || section === "header" || section === "contact") return;
       if (!grouped.has(section)) grouped.set(section, []);
@@ -176,90 +113,370 @@
     return grouped;
   }
 
-
-  function expandSkillsItems(items) {
-    const expanded = [];
-    for (const item of items) {
-      const content = String(item?.content || "");
-      const bulletLines = content
-        .split(/\r?\n/)
-        .map((line) => line.trim())
-        .filter((line) => /^[-*]\s+/.test(line));
-
-      if (bulletLines.length >= 2) {
-        bulletLines.forEach((line, index) => {
-          expanded.push({
-            ...item,
-            title: "",
-            subtitle: "",
-            location: "",
-            start: "",
-            end: "",
-            dispdate: "",
-            manualsort: item.manualsort ? `${item.manualsort}.${String(index + 1).padStart(3, "0")}` : "",
-            content: line
-          });
-        });
-      } else {
-        expanded.push(item);
-      }
-    }
-    return expanded;
-  }
-
-  function renderColumns(items, mainHost, railHost) {
+  function toAtoms(items) {
     const grouped = groupBySection(items);
-    mainHost.innerHTML = "";
-    railHost.innerHTML = "";
+    const mainFirst = [];
+    const mainLater = [];
+    const railSkills = [];
+    const railPage2 = [];
+    const railLater = [];
 
-    const mainConfig = [
-      { key: "core competencies", title: "Core Competencies" },
-      { key: "work experience", title: "Work Experience" },
-      { key: "technical + it", title: "Technical + IT" }
-    ];
+    mainFirst.push(...sectionEntries("Core Competencies", grouped.get("core competencies") || [], { hideEntryTitleWhenSameAsSection: true }));
+    mainFirst.push(...workAndTechEntries(grouped.get("work experience") || [], grouped.get("technical + it") || []));
 
+    railSkills.push(...sectionEntries("Skills", splitSkillsBullets(grouped.get("topline skills") || [])));
+    railPage2.push(...sectionEntries("Education", grouped.get("education") || []));
 
-    mainConfig.forEach((cfg) => {
-      const sectionItems = grouped.get(cfg.key) || [];
-      const hideTitle = cfg.key === "core competencies";
-      renderSection(mainHost, cfg.title, sectionItems, { hideEntryTitleWhenSameAsSection: hideTitle });
-      grouped.delete(cfg.key);
+    sortItems(grouped.get("second page rail") || []).forEach((item) => {
+      if (!item.title) return;
+      railLater.push({ type: "section-title", title: item.title, units: 0.5 });
+      railLater.push({ type: "entry", item: { ...item, content: item.content || "" }, hideTitle: true, units: estimateUnits(item, true) });
     });
 
-    const skillsItems = grouped.get("topline skills") || [];
-    const educationItems = grouped.get("education") || [];
-    const secondRailItems = grouped.get("second page rail") || [];
+    grouped.delete("core competencies");
+    grouped.delete("work experience");
+    mainLater.push(...sectionEntries("CV Footer", grouped.get("footer") || [], { hideSectionTitle: true, hideAllEntryTitles: true }));
 
-    renderSection(railHost, "Skills", expandSkillsItems(skillsItems), { hideEntryTitleWhenSameAsSection: false });
-    renderSection(railHost, "Education", educationItems, { hideEntryTitleWhenSameAsSection: false });
-    renderSecondRail(railHost, secondRailItems);
-
+    grouped.delete("technical + it");
     grouped.delete("topline skills");
     grouped.delete("education");
     grouped.delete("second page rail");
+    grouped.delete("footer");
 
     [...grouped.keys()].sort().forEach((extraKey) => {
-      renderSection(mainHost, titleCase(extraKey), grouped.get(extraKey), { hideEntryTitleWhenSameAsSection: false });
+      const title = extraKey.split(/\s+/).map((w) => w.charAt(0).toUpperCase() + w.slice(1)).join(" ");
+      mainLater.push(...sectionEntries(title, grouped.get(extraKey) || []));
+    });
+
+    return { mainFirst, mainLater, railSkills, railPage2, railLater };
+  }
+
+
+  function fillPage(atoms, index, budget) {
+    const out = [];
+    let used = 0;
+    let i = index;
+    while (i < atoms.length) {
+      const next = atoms[i];
+      if (used + next.units > budget && out.length) break;
+      out.push(next);
+      used += next.units;
+      i += 1;
+    }
+    return { nextIndex: i, atoms: out };
+  }
+
+  function paginate(mainFirstAtoms, mainLaterAtoms, railSkillsAtoms, railPage2Atoms, railLaterAtoms) {
+    const pages = [];
+    let mf = 0;
+    let rs = 0;
+
+    const firstMain = fillPage(mainFirstAtoms, mf, 85);
+    const firstRail = fillPage(railSkillsAtoms, rs, 55);
+    pages.push({ main: firstMain.atoms, rail: firstRail.atoms, first: true });
+    mf = firstMain.nextIndex;
+    rs = firstRail.nextIndex;
+
+    const mainRemainder = mainFirstAtoms.slice(mf).concat(mainLaterAtoms);
+    const railRemainder = railPage2Atoms.concat(railSkillsAtoms.slice(rs), railLaterAtoms);
+
+    let mr = 0;
+    let rr = 0;
+
+    if (mr < mainRemainder.length || rr < railRemainder.length) {
+      const secondMain = fillPage(mainRemainder, mr, 98);
+      const secondRail = fillPage(railRemainder, rr, 220);
+      pages.push({ main: secondMain.atoms, rail: secondRail.atoms, first: false });
+      mr = secondMain.nextIndex;
+      rr = secondRail.nextIndex;
+    }
+
+    let guard = 0;
+    while (mr < mainRemainder.length || rr < railRemainder.length) {
+      const mainSlice = fillPage(mainRemainder, mr, 110);
+      const railSlice = fillPage(railRemainder, rr, 110);
+      pages.push({ main: mainSlice.atoms, rail: railSlice.atoms, first: false });
+      mr = mainSlice.nextIndex;
+      rr = railSlice.nextIndex;
+      guard += 1;
+      if (guard > 20) break;
+    }
+    return pages.filter((p) => p.main.length || p.rail.length);
+  }
+
+
+
+  function renderEntryAtom(atom) {
+    const { item, hideTitle } = atom;
+    const article = document.createElement("article");
+    article.className = "entry";
+    if (item.title && !hideTitle) {
+      const el = document.createElement("h4");
+      el.className = "entry-title";
+      el.textContent = item.title;
+      article.appendChild(el);
+    }
+    if (item.subtitle || item.location) {
+      const meta = document.createElement("div");
+      meta.className = "entry-meta";
+      meta.textContent = [item.subtitle, item.location].filter(Boolean).join(" • ");
+      article.appendChild(meta);
+    }
+    const dateText = displayDate(item);
+    if (dateText) {
+      const date = document.createElement("div");
+      date.className = "entry-date";
+      date.textContent = dateText;
+      article.appendChild(date);
+    }
+    if (item.content) {
+      const content = document.createElement("div");
+      content.className = "entry-content";
+      content.innerHTML = markdownToHtml(item.content);
+      article.appendChild(content);
+    }
+    return article;
+  }
+
+  function renderColumnAtoms(host, atoms, cls) {
+    host.innerHTML = "";
+    let section = null;
+    atoms.forEach((atom) => {
+      if (atom.type === "section-title") {
+        section = document.createElement("section");
+        section.className = `section ${cls}`;
+        section.innerHTML = `<h3>${atom.title}</h3>`;
+        host.appendChild(section);
+        return;
+      }
+      if (!section) {
+        section = document.createElement("section");
+        section.className = `section ${cls}`;
+        host.appendChild(section);
+      }
+      section.appendChild(renderEntryAtom(atom));
     });
   }
 
-  function renderStandardCv({ items, headerEl, contactEl, mainEl, railEl }) {
-    const header = items.find((item) => key(item.section) === "header") || {};
-    const contacts = items.filter((item) => key(item.section) === "contact");
-    renderHeader(headerEl, header);
-    renderContact(contactEl, contacts, true);
-    renderColumns(items, mainEl, railEl);
+  function renderFooterContent(host, techItems, footerItems) {
+    if (!host) return;
+    host.innerHTML = "";
+
+    const tech = sortItems(techItems || []);
+    if (tech.length) {
+      const techSection = document.createElement("section");
+      techSection.className = "section footer-tech";
+      techSection.innerHTML = "<h3>Technical + IT</h3>";
+      const techGrid = document.createElement("div");
+      techGrid.className = "tech-grid";
+      tech.forEach((item) => {
+        techGrid.appendChild(renderEntryAtom({ type: "entry", item, hideTitle: false, units: estimateUnits(item, false) }));
+      });
+      techSection.appendChild(techGrid);
+      host.appendChild(techSection);
+    }
+
+    const footer = sortItems(footerItems || []);
+    if (footer.length) {
+      const footerSection = document.createElement("section");
+      footerSection.className = "section footer-block";
+      footer.forEach((item) => {
+        footerSection.appendChild(renderEntryAtom({ type: "entry", item: { ...item, title: "" }, hideTitle: true, units: estimateUnits(item, false) }));
+      });
+      host.appendChild(footerSection);
+    }
   }
 
-  global.CvRender = {
-    key,
-    sortItems,
-    renderStandardCv,
-    groupBySection,
-    renderColumns,
-    renderSection,
-    renderSecondRail,
-    renderHeader,
-    renderContact
-  };
+  function renderHeader(host, item) {
+    host.innerHTML = `<h1>${item?.title || "CV"}</h1><h2>${item?.subtitle || ""}</h2><div class="header-summary">${markdownToHtml(item?.content || "")}</div>`;
+  }
+
+  function iconClassForContact(text) {
+    const v = String(text || "").toLowerCase();
+    if (v.includes("@")) return "fa-solid fa-envelope";
+    if (v.includes("http") || v.includes("www.")) return "fa-solid fa-globe";
+    if (/[+()\d\s-]{7,}/.test(v)) return "fa-solid fa-phone";
+    return "fa-solid fa-address-card";
+  }
+
+  function renderContact(host, items) {
+    const entries = items.filter((item) => String(item?.content || "").trim() !== "");
+    if (!entries.length) { host.style.display = "none"; return; }
+    host.style.display = "grid";
+    host.innerHTML = entries.map((item) => `<div class="contact-item"><i class="${iconClassForContact(item.content)}" aria-hidden="true"></i><span>${item.content || ""}</span></div>`).join("");
+  }
+
+  function splitWorkPageOne(workItems, budget) {
+    const page1WorkItems = [];
+    const page2WorkItems = [];
+    let used = 0;
+    let overflowStarted = false;
+    workItems.forEach((item, idx) => {
+      const units = estimateUnits(item, false);
+      if (!overflowStarted && (idx === 0 || used + units <= budget)) {
+        page1WorkItems.push(item);
+        used += units;
+      } else {
+        overflowStarted = true;
+        page2WorkItems.push(item);
+      }
+    });
+    return { page1WorkItems, page2WorkItems, used };
+  }
+
+  function composeFiveBlockLayout(items) {
+    const source = Array.isArray(items) ? items : [];
+    const grouped = groupBySection(source);
+
+    const coreAtoms = sectionEntries("Core Competencies", grouped.get("core competencies") || [], { hideEntryTitleWhenSameAsSection: true });
+    const workItems = grouped.get("work experience") || [];
+    let workPage1Budget = 23;
+    let split = splitWorkPageOne(workItems, workPage1Budget);
+    const leftover = workPage1Budget - split.used;
+    const firstOverflowUnits = split.page2WorkItems.length ? estimateUnits(split.page2WorkItems[0], false) : 0;
+    const barelyMissed = split.page2WorkItems.length > 0 && firstOverflowUnits > leftover && (firstOverflowUnits - leftover) <= 1.2;
+    if (barelyMissed) {
+      workPage1Budget += 1.2;
+      split = splitWorkPageOne(workItems, workPage1Budget);
+    }
+    const compact = barelyMissed;
+
+    if (split.page2WorkItems.length) {
+      const promoteUnits = estimateUnits(split.page2WorkItems[0], false);
+      const promoteThreshold = compact ? 9.5 : 8.5;
+      if (workPage1Budget - split.used + promoteUnits >= promoteThreshold) {
+        split.page1WorkItems.push(split.page2WorkItems.shift());
+      }
+    }
+
+    const mainPage1Atoms = coreAtoms.concat(sectionEntriesOrdered("Work Experience", split.page1WorkItems));
+    const mainPage2Atoms = [];
+    if (split.page2WorkItems.length) {
+      mainPage2Atoms.push(...sectionEntriesOrdered("Work Experience (Cont.)", split.page2WorkItems));
+    }
+    const footerTechItems = sortItems(grouped.get("technical + it") || []);
+    const footerItems = sortItems(grouped.get("footer") || []);
+
+    grouped.delete("core competencies");
+    grouped.delete("work experience");
+    grouped.delete("technical + it");
+    grouped.delete("footer");
+
+    [...grouped.keys()].sort().forEach((extraKey) => {
+      if (["topline skills", "education", "second page rail", "footer"].includes(extraKey)) return;
+      const title = extraKey.split(/\s+/).map((w) => w.charAt(0).toUpperCase() + w.slice(1)).join(" ");
+      mainPage2Atoms.push(...sectionEntries(title, grouped.get(extraKey) || []));
+    });
+
+    const railPage1Atoms = [];
+    railPage1Atoms.push(...sectionEntries("Skills", grouped.get("topline skills") || []));
+
+    const railPage2Atoms = [];
+    railPage2Atoms.push(...sectionEntries("Education", grouped.get("education") || []));
+    sortItems(grouped.get("second page rail") || []).forEach((item) => {
+      if (!item.title) return;
+      railPage2Atoms.push({ type: "section-title", title: item.title, units: 0.5 });
+      railPage2Atoms.push({ type: "entry", item: { ...item, content: item.content || "" }, hideTitle: true, units: estimateUnits(item, true) });
+    });
+
+    return { mainPage1Atoms, mainPage2Atoms, railPage1Atoms, railPage2Atoms, footerTechItems, footerItems, compact };
+  }
+
+  function renderStandardCv({ items, headerEl, contactEl, mainEl, railEl, footerEl }) {
+    const source = Array.isArray(items) ? items : [];
+    const grouped = groupBySection(source);
+    const header = source.find((item) => key(item.section) === "header") || {};
+    const contacts = source.filter((item) => key(item.section) === "contact");
+
+    renderHeader(headerEl, header);
+    renderContact(contactEl, contacts);
+
+    const mainAtoms = [];
+    mainAtoms.push(...sectionEntries("Core Competencies", grouped.get("core competencies") || [], { hideEntryTitleWhenSameAsSection: true }));
+    mainAtoms.push(...sectionEntries("Work Experience", grouped.get("work experience") || []));
+
+    const footerTechItems = sortItems(grouped.get("technical + it") || []);
+    const footerItems = sortItems(grouped.get("footer") || []);
+
+    grouped.delete("core competencies");
+    grouped.delete("work experience");
+    grouped.delete("technical + it");
+    grouped.delete("footer");
+
+    [...grouped.keys()].sort().forEach((extraKey) => {
+      if (["topline skills", "education", "second page rail", "footer"].includes(extraKey)) return;
+      const title = extraKey.split(/\s+/).map((w) => w.charAt(0).toUpperCase() + w.slice(1)).join(" ");
+      mainAtoms.push(...sectionEntries(title, grouped.get(extraKey) || []));
+    });
+
+    const railAtoms = [];
+    railAtoms.push(...sectionEntries("Skills", grouped.get("topline skills") || []));
+    railAtoms.push(...sectionEntries("Education", grouped.get("education") || []));
+    sortItems(grouped.get("second page rail") || []).forEach((item) => {
+      if (!item.title) return;
+      railAtoms.push({ type: "section-title", title: item.title, units: 0.5 });
+      railAtoms.push({ type: "entry", item: { ...item, content: item.content || "" }, hideTitle: true, units: estimateUnits(item, true) });
+    });
+
+    renderColumnAtoms(mainEl, mainAtoms, "col-main");
+    renderColumnAtoms(railEl, railAtoms, "col-rail");
+    if (footerEl) {
+      renderFooterContent(footerEl, footerTechItems, footerItems);
+    } else if (mainEl) {
+      const fallbackFooter = document.createElement("div");
+      fallbackFooter.className = "footer";
+      renderFooterContent(fallbackFooter, footerTechItems, footerItems);
+      mainEl.appendChild(fallbackFooter);
+    }
+  }
+
+  function renderPaginatedCv(root, cv) {
+    const items = Array.isArray(cv?.items) ? cv.items : [];
+    const header = items.find((item) => key(item.section) === "header") || {};
+    const contacts = items.filter((item) => key(item.section) === "contact");
+    const blocks = composeFiveBlockLayout(items);
+
+    root.innerHTML = "";
+    root.classList.toggle("compact", Boolean(blocks.compact));
+
+    const full = document.createElement("div");
+    full.className = "full-container";
+
+    const headerContainer = document.createElement("div");
+    headerContainer.className = "header-container";
+    const headerEl = document.createElement("header");
+    headerEl.className = "header";
+    renderHeader(headerEl, header);
+    headerContainer.appendChild(headerEl);
+    const contactEl = document.createElement("section");
+    contactEl.className = "contact-bar";
+    renderContact(contactEl, contacts);
+    headerContainer.appendChild(contactEl);
+
+    const railPage1 = document.createElement("div");
+    railPage1.className = "rail-page-1";
+    renderColumnAtoms(railPage1, blocks.railPage1Atoms, "col-rail");
+
+    const mainPage1 = document.createElement("div");
+    mainPage1.className = "main-content-1";
+    renderColumnAtoms(mainPage1, blocks.mainPage1Atoms, "col-main");
+
+    const railPage2 = document.createElement("div");
+    railPage2.className = "rail-page-2";
+    renderColumnAtoms(railPage2, blocks.railPage2Atoms, "col-rail");
+
+    const mainPage2 = document.createElement("div");
+    mainPage2.className = "main-content-2";
+    renderColumnAtoms(mainPage2, blocks.mainPage2Atoms, "col-main");
+
+    const footer = document.createElement("div");
+    footer.className = "footer";
+    renderFooterContent(footer, blocks.footerTechItems, blocks.footerItems);
+
+    full.append(headerContainer, railPage1, mainPage1, railPage2, mainPage2, footer);
+    root.appendChild(full);
+  }
+
+
+  global.CvRender = { key, sortItems, renderStandardCv, renderPaginatedCv };
 })(window);

--- a/cv.html
+++ b/cv.html
@@ -44,7 +44,6 @@
         margin: 0 auto 12px;
         display: flex;
         justify-content: flex-end;
-        gap: 10px;
       }
 
       .btn {
@@ -120,6 +119,10 @@
       .entry-content ul, .entry-content ol { margin: 0; padding-left: 0; list-style: none; }
       .entry-content li { margin: 0 0 5px; padding-left: 12px; position: relative; }
       .entry-content li::before { content: "•"; position: absolute; left: 0; }
+      .footer { grid-column: 1 / -1; margin-top: 8px; }
+      .tech-grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 12px; }
+      .tech-grid .entry { margin-bottom: 0; }
+      .footer-block { margin-top: 12px; }
 
       .error {
         margin: 20px;
@@ -136,14 +139,14 @@
         .contact-bar { grid-template-columns: 1fr; }
         .contact-item { border-right: 0; border-bottom: 1px solid #4b555f; }
         .contact-item:last-child { border-bottom: 0; padding-left: 0; }
+        .tech-grid { grid-template-columns: 1fr; }
       }
     </style>
   </head>
   <body>
     <div class="shell">
       <div class="actions">
-        <a class="btn" id="print-link" href="#">Print / PDF</a>
-        <button class="btn" id="share-btn">Share</button>
+        <a class="btn" id="pdf-link" href="#" target="_blank" rel="noopener noreferrer">View PDF</a>
       </div>
 
       <main class="page">
@@ -152,15 +155,131 @@
         <section class="content">
           <div id="main-col"></div>
           <div id="rail-col"></div>
+          <div class="footer" id="footer-col"></div>
         </section>
       </main>
     </div>
 
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
-    <script src="cv-render.js"></script>
     <script>
       const query = new URLSearchParams(window.location.search);
       const slug = (query.get("cv") || "").trim().toLowerCase();
+
+      function ensureRendererLoaded(){ return Promise.resolve(); }
+
+      function key(v) { return String(v || "").trim().toLowerCase(); }
+      function sortItems(items) {
+        return [...(items || [])].sort((a, b) => {
+          const ak = String(a?.manualsort || "").trim();
+          const bk = String(b?.manualsort || "").trim();
+          if (ak && bk) return ak.localeCompare(bk, undefined, { numeric: true, sensitivity: "base" });
+          if (ak) return -1;
+          if (bk) return 1;
+          return 0;
+        });
+      }
+      function markdownToHtml(value) {
+        const text = String(value || "");
+        if (!text) return "";
+        if (window.marked?.parse) return window.marked.parse(text);
+        return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/\n/g, "<br>");
+      }
+      function displayDate(item) {
+        if (item?.dispdate) return item.dispdate;
+        const start = item?.start || "";
+        const end = item?.end || "Present";
+        return start ? `${start} – ${end}` : "";
+      }
+      function iconClassForContact(text) {
+        const v = String(text || "").toLowerCase();
+        if (v.includes("@")) return "fa-solid fa-envelope";
+        if (v.includes("http") || v.includes("www.")) return "fa-solid fa-globe";
+        if (/[+()\d\s-]{7,}/.test(v)) return "fa-solid fa-phone";
+        return "fa-solid fa-address-card";
+      }
+      function renderEntry(item, hideTitle = false) {
+        const article = document.createElement("article");
+        article.className = "entry";
+        if (item?.title && !hideTitle) {
+          const el = document.createElement("h4");
+          el.className = "entry-title";
+          el.textContent = item.title;
+          article.appendChild(el);
+        }
+        const meta = [item?.subtitle, item?.location].filter(Boolean).join(" • ");
+        if (meta) {
+          const el = document.createElement("div");
+          el.className = "entry-meta";
+          el.textContent = meta;
+          article.appendChild(el);
+        }
+        const date = displayDate(item);
+        if (date) {
+          const el = document.createElement("div");
+          el.className = "entry-date";
+          el.textContent = date;
+          article.appendChild(el);
+        }
+        if (item?.content) {
+          const el = document.createElement("div");
+          el.className = "entry-content";
+          el.innerHTML = markdownToHtml(item.content);
+          article.appendChild(el);
+        }
+        return article;
+      }
+      function renderSection(host, title, items, options = {}) {
+        if (!items.length) return;
+        const sec = document.createElement("section");
+        sec.className = "section";
+        if (!options.hideSectionTitle) {
+          const h3 = document.createElement("h3");
+          h3.textContent = title;
+          sec.appendChild(h3);
+        }
+        items.forEach((item) => sec.appendChild(renderEntry(item, options.hideAllEntryTitles || false)));
+        host.appendChild(sec);
+      }
+      function renderFallbackCv({ items, headerEl, contactEl, mainEl, railEl, footerEl }) {
+        const all = Array.isArray(items) ? items : [];
+        const header = all.find((item) => key(item.section) === "header") || {};
+        const contacts = all.filter((item) => key(item.section) === "contact");
+
+        headerEl.innerHTML = `<h1>${header?.title || "CV"}</h1><h2>${header?.subtitle || ""}</h2><div class="header-summary">${markdownToHtml(header?.content || "")}</div>`;
+        contactEl.innerHTML = contacts.map((item) => `<div class="contact-item"><i class="${iconClassForContact(item?.content)}" aria-hidden="true"></i><span>${item?.content || ""}</span></div>`).join("");
+
+        const grouped = new Map();
+        all.forEach((item) => {
+          const section = key(item.section);
+          if (!section || section === "header" || section === "contact") return;
+          if (!grouped.has(section)) grouped.set(section, []);
+          grouped.get(section).push(item);
+        });
+
+        mainEl.innerHTML = "";
+        railEl.innerHTML = "";
+        footerEl.innerHTML = "";
+
+        renderSection(mainEl, "Core Competencies", sortItems(grouped.get("core competencies") || []), { hideAllEntryTitles: true });
+        renderSection(mainEl, "Work Experience", sortItems(grouped.get("work experience") || []));
+        renderSection(mainEl, "Topline Skills", sortItems(grouped.get("topline skills") || []));
+
+        const tech = sortItems(grouped.get("technical + it") || []);
+        if (tech.length) {
+          const techWrap = document.createElement("section");
+          techWrap.className = "section footer-tech";
+          techWrap.innerHTML = `<h3>Technical + IT</h3><div class="tech-grid"></div>`;
+          const grid = techWrap.querySelector('.tech-grid');
+          tech.forEach((item) => grid.appendChild(renderEntry(item)));
+          footerEl.appendChild(techWrap);
+        }
+
+        renderSection(railEl, "Education", sortItems(grouped.get("education") || []));
+        const spr = sortItems(grouped.get("second page rail") || []);
+        spr.forEach((item) => renderSection(railEl, item?.title || "Second Page Rail", [{ ...item, title: "" }], { hideAllEntryTitles: true }));
+
+        renderSection(footerEl, "CV Footer", sortItems(grouped.get("footer") || []), { hideSectionTitle: true, hideAllEntryTitles: true });
+      }
 
       async function init() {
         if (!slug) {
@@ -173,22 +292,19 @@
           if (!response.ok) throw new Error(`Unable to load data/cv/${slug}.json (HTTP ${response.status})`);
           const cv = await response.json();
           const items = Array.isArray(cv.items) ? cv.items : [];
-          window.CvRender.renderStandardCv({
+
+          const args = {
             items,
             headerEl: document.getElementById("header"),
             contactEl: document.getElementById("contact"),
             mainEl: document.getElementById("main-col"),
-            railEl: document.getElementById("rail-col")
-          });
+            railEl: document.getElementById("rail-col"),
+            footerEl: document.getElementById("footer-col")
+          };
 
-          document.getElementById("print-link").href = `cv-print.html?cv=${encodeURIComponent(slug)}`;
+          renderFallbackCv(args);
 
-          const personName = items.find((item) => window.CvRender.key(item.section) === "header")?.title || "CV";
-          document.getElementById("share-btn").addEventListener("click", async () => {
-            const url = window.location.href;
-            await navigator.clipboard.writeText(`Check out the CV of ${personName}: ${url}`);
-            alert("Copied CV link to clipboard.");
-          });
+          document.getElementById("pdf-link").href = `dist/${encodeURIComponent(slug)}.pdf`;
         } catch (error) {
           document.body.innerHTML = `<div class="error">${error.message}</div>`;
         }

--- a/cv/index.html
+++ b/cv/index.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>CV Viewer</title>
+  <style>
+    body { margin: 0; font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; background: #f3f4f6; }
+    .shell { max-width: 1240px; margin: 0 auto; padding: 16px 12px 28px; }
+    .actions { display: flex; justify-content: flex-end; margin-bottom: 10px; }
+    .btn { border: 0; border-radius: 999px; background: #1f2937; color: #fff; padding: 10px 16px; font-size: 13px; font-weight: 600; text-decoration: none; }
+    .error { margin: 20px; background: #fceaea; border: 1px solid #f0c5c5; color: #8b1111; border-radius: 8px; padding: 12px; }
+  </style>
+</head>
+<body>
+  <main class="shell">
+    <div class="actions">
+      <a class="btn" id="pdf-link" href="#" target="_blank" rel="noopener noreferrer">View PDF</a>
+    </div>
+
+    <div id="cv-embed-target"></div>
+  </main>
+
+  <script>
+    (function () {
+      const slug = (new URLSearchParams(window.location.search).get("cv") || "").trim().toLowerCase();
+      if (!slug) {
+        document.body.innerHTML = '<div class="error">Missing <code>?cv=&lt;slug&gt;</code> query parameter.</div>';
+        return;
+      }
+
+      const basePath = window.location.pathname.replace(/\/cv\/?$/, "");
+      document.getElementById("pdf-link").href = `${basePath}/dist/${encodeURIComponent(slug)}.pdf`;
+
+      const script = document.createElement("script");
+      script.src = `${window.location.origin}${basePath}/cv-embed.js`;
+      script.setAttribute("data-cv", slug);
+      script.setAttribute("data-target", "cv-embed-target");
+      document.body.appendChild(script);
+    })();
+  </script>
+</body>
+</html>

--- a/dist/coleman-davis.pdf-recap.md
+++ b/dist/coleman-davis.pdf-recap.md
@@ -1,0 +1,24 @@
+# PDF Recap: coleman-davis
+
+- Generated: 2026-03-19T08:17:35.627Z
+- CV title: Coleman DAVIS
+- CV subtitle: Digital Communications & Strategy Lead
+- Layout mode: standard
+- HTTP mode: disabled
+- Legacy press-ready mode: disabled
+
+## Page content totals
+
+- Page 1 main column: 2 sections, 3 entries
+- Page 1 rail column: 1 sections, 4 entries
+- Page 2 main column: 1 sections, 3 entries
+- Page 2 rail column: 5 sections, 5 entries
+- Footer technical items: 5
+- Footer items: 0
+
+## Section titles by column
+
+- Page 1 main: Core Competencies, Work Experience
+- Page 1 rail: Skills
+- Page 2 main: Work Experience (Cont.)
+- Page 2 rail: Education, Work Eligibility, Languages, Soft Skills, References

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "build:json": "node scripts/build-cv-json.js",
     "pdf:build": "node scripts/build-cv-pdf.js",
-    "pdf:preview": "vivliostyle preview cv-print.html"
+    "pdf:preview": "vivliostyle preview cv-print.html",
+    "ai:feedback": "node scripts/run-cv-ai-feedback.js"
   },
   "devDependencies": {
     "@vivliostyle/cli": "^8.15.1"

--- a/scripts/build-cv-json.js
+++ b/scripts/build-cv-json.js
@@ -66,6 +66,63 @@ function valueOrNull(value) {
   return value === undefined ? null : value;
 }
 
+
+function normalizeRichTextFieldValue(value) {
+  if (value === undefined || value === null) return "";
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+
+  if (Array.isArray(value)) {
+    return value.map((part) => normalizeRichTextFieldValue(part)).join("").trim();
+  }
+
+  if (typeof value === "object") {
+    const directKeys = ["text", "plain_text", "value", "content", "name"];
+    for (const key of directKeys) {
+      if (typeof value[key] === "string") return value[key];
+    }
+
+    const nestedKeys = ["text", "value", "content", "children", "richText", "rich_text"];
+    const nestedParts = [];
+    for (const key of nestedKeys) {
+      if (value[key] !== undefined && value[key] !== null) {
+        const normalized = normalizeRichTextFieldValue(value[key]);
+        if (normalized) nestedParts.push(normalized);
+      }
+    }
+    if (nestedParts.length) return nestedParts.join(" ").trim();
+
+    const fallback = [];
+    for (const v of Object.values(value)) {
+      const normalized = normalizeRichTextFieldValue(v);
+      if (normalized) fallback.push(normalized);
+    }
+    return fallback.join(" ").trim();
+  }
+
+  return String(value);
+}
+
+
+function getCvFooterValue(fields) {
+  const direct = [fields["CV_Footer"], fields["CV Footer"]];
+  for (const candidate of direct) {
+    const normalized = normalizeRichTextFieldValue(candidate);
+    if (normalized) return normalized;
+  }
+
+  const normalizeFieldName = (name) => String(name || "").toLowerCase().replace(/[^a-z0-9]/g, "");
+  const target = "cvfooter";
+  for (const [fieldName, fieldValue] of Object.entries(fields || {})) {
+    if (normalizeFieldName(fieldName) !== target) continue;
+    const normalized = normalizeRichTextFieldValue(fieldValue);
+    if (normalized) return normalized;
+  }
+
+  return "";
+}
+
+
 function pushContact(items, title, value) {
   if (value !== undefined && value !== null && String(value).trim() !== "") {
     items.push({ title, content: value, section: "contact" });
@@ -166,6 +223,7 @@ async function fetchCvItems(recordId, linkedItemIds = []) {
 function mapItem(record) {
   const f = record.fields || {};
   return {
+    recordId: record.id,
     title: valueOrNull(f["Headline"]),
     subtitle: valueOrNull(f["Organization / Subtitle"]),
     location: valueOrNull(f["Location"]),
@@ -174,7 +232,8 @@ function mapItem(record) {
     dispdate: valueOrNull(f["Display Date"]),
     content: valueOrNull(f["Content"]),
     section: valueOrNull(f["Section"]),
-    manualsort: valueOrNull(f["Manual sort"])
+    manualsort: valueOrNull(f["Manual sort"]),
+    aiFeedback: valueOrNull(normalizeRichTextFieldValue(f["AI Feedback"]))
   };
 }
 
@@ -222,6 +281,15 @@ async function buildAndWriteCv(cvRecord) {
   pushContact(items, "Phone", fields["Contact: Phone Number"]);
   pushCoreCompetencies(items, fields["Core Competencies"]);
 
+  const cvFooter = getCvFooterValue(fields);
+  if (String(cvFooter).trim() !== "") {
+    items.push({
+      title: "CV Footer",
+      content: valueOrNull(cvFooter),
+      section: "footer"
+    });
+  }
+
   const linkedCvItems = Array.isArray(fields["CV Items"]) ? fields["CV Items"] : [];
   const cvItems = await fetchCvItems(cvRecord.id, linkedCvItems);
 
@@ -230,7 +298,17 @@ async function buildAndWriteCv(cvRecord) {
     .sort(compareManualSort)
     .forEach((item) => items.push(item));
 
-  const output = { slug, status, items };
+  const output = {
+    slug,
+    status,
+    feedback: {
+      overall: valueOrNull(normalizeRichTextFieldValue(fields["Overall AI Feedback"])),
+      intro: valueOrNull(normalizeRichTextFieldValue(fields["AI Feedback Intro"])),
+      coreCompetencies: valueOrNull(normalizeRichTextFieldValue(fields["AI Feedback Core Competencies"])),
+      footer: valueOrNull(normalizeRichTextFieldValue(fields["AI Feedback Footer"]))
+    },
+    items
+  };
   fs.mkdirSync(path.dirname(outputPath), { recursive: true });
   fs.writeFileSync(outputPath, `${JSON.stringify(output, null, 2)}\n`, "utf8");
 
@@ -260,6 +338,7 @@ async function main() {
 
   const cvRecord = await fetchCvRecord(issueRecordId);
   const result = await buildAndWriteCv(cvRecord);
+
   setOutput("record_id", issueRecordId);
   setOutput("slug", result.slug);
   setOutput("relative_path", result.relativePath);

--- a/scripts/build-cv-pdf.js
+++ b/scripts/build-cv-pdf.js
@@ -12,49 +12,7 @@ function escapeHtml(value) {
     .replace(/'/g, "&#39;");
 }
 
-function key(value) {
-  return String(value || "").trim().toLowerCase();
-}
-
-function inlineMarkdownToHtml(text) {
-  const escaped = escapeHtml(text);
-  return escaped
-    .replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>")
-    .replace(/\*(.+?)\*/g, "<em>$1</em>")
-    .replace(/`(.+?)`/g, "<code>$1</code>")
-    .replace(/\[(.+?)\]\((https?:[^\s)]+)\)/g, '<a href="$2">$1</a>');
-}
-
-function markdownToHtml(markdown) {
-  const raw = String(markdown || "").trim();
-  if (!raw) return "";
-
-  const lines = raw.split(/\r?\n/);
-  const chunks = [];
-  let listItems = [];
-
-  const flushList = () => {
-    if (!listItems.length) return;
-    const items = listItems.map((item) => `<li>${inlineMarkdownToHtml(item)}</li>`).join("");
-    chunks.push(`<ul>${items}</ul>`);
-    listItems = [];
-  };
-
-  for (const line of lines) {
-    const trimmed = line.trim();
-    const bullet = trimmed.match(/^[-*]\s+(.*)$/);
-    if (bullet) {
-      listItems.push(bullet[1]);
-      continue;
-    }
-    flushList();
-    if (!trimmed) continue;
-    chunks.push(`<p>${inlineMarkdownToHtml(trimmed)}</p>`);
-  }
-
-  flushList();
-  return chunks.join("\n");
-}
+function key(value) { return String(value || "").trim().toLowerCase(); }
 
 function parseDateValue(value) {
   if (!value) return Number.NEGATIVE_INFINITY;
@@ -66,17 +24,12 @@ function sortItems(items) {
   return [...items].sort((a, b) => {
     const aManual = String(a.manualsort || "").trim();
     const bManual = String(b.manualsort || "").trim();
-    if (aManual && bManual && aManual !== bManual) {
-      return aManual.localeCompare(bManual, undefined, { numeric: true, sensitivity: "base" });
-    }
+    if (aManual && bManual && aManual !== bManual) return aManual.localeCompare(bManual, undefined, { numeric: true, sensitivity: "base" });
     if (aManual && !bManual) return -1;
     if (!aManual && bManual) return 1;
-
     const byStart = parseDateValue(b.start) - parseDateValue(a.start);
     if (byStart !== 0) return byStart;
-    const byEnd = parseDateValue(b.end) - parseDateValue(a.end);
-    if (byEnd !== 0) return byEnd;
-    return 0;
+    return parseDateValue(b.end) - parseDateValue(a.end);
   });
 }
 
@@ -98,217 +51,396 @@ function displayDate(item) {
   return end;
 }
 
-function renderEntry(item, options = {}) {
+function inlineMarkdownToHtml(text) {
+  const escaped = escapeHtml(text);
+  return escaped
+    .replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>")
+    .replace(/\*(.+?)\*/g, "<em>$1</em>")
+    .replace(/`(.+?)`/g, "<code>$1</code>")
+    .replace(/\[(.+?)\]\((https?:[^\s)]+)\)/g, '<a href="$2">$1</a>');
+}
+
+function markdownToHtml(markdown) {
+  const raw = String(markdown || "").trim();
+  if (!raw) return "";
+  const lines = raw.split(/\r?\n/);
+  const chunks = [];
+  let list = [];
+  const flush = () => {
+    if (!list.length) return;
+    chunks.push(`<ul>${list.map((x) => `<li>${inlineMarkdownToHtml(x)}</li>`).join("")}</ul>`);
+    list = [];
+  };
+  lines.forEach((line) => {
+    const t = line.trim();
+    const bullet = t.match(/^[-*]\s+(.*)$/);
+    if (bullet) { list.push(bullet[1]); return; }
+    flush();
+    const heading = t.match(/^(#{1,6})\s+(.*)$/);
+    if (heading) {
+      const level = Math.min(6, heading[1].length);
+      chunks.push(`<h${level}>${inlineMarkdownToHtml(heading[2])}</h${level}>`);
+      return;
+    }
+    if (t) chunks.push(`<p>${inlineMarkdownToHtml(t)}</p>`);
+  });
+  flush();
+  return chunks.join("\n");
+}
+
+function estimateUnits(item, isRail = false) {
+  const text = `${item.title || ""} ${item.subtitle || ""} ${item.location || ""} ${item.content || ""}`.trim();
+  const chars = text.length;
+  const perLine = isRail ? 52 : 68;
+  const lines = Math.max(1, Math.ceil(chars / perLine));
+  const base = isRail ? 0.9 : 1.2;
+  const contentPenalty = item.content ? (isRail ? 0.8 : 1.1) : 0;
+  return base + lines + contentPenalty;
+}
+
+function splitSkillsBullets(items) {
+  const out = [];
+  for (const item of items) {
+    const lines = String(item?.content || "").split(/\r?\n/).map((l) => l.trim()).filter((l) => /^[-*]\s+/.test(l));
+    if (lines.length < 2) { out.push(item); continue; }
+    lines.forEach((line, index) => out.push({ ...item, title: "", subtitle: "", location: "", start: "", end: "", dispdate: "", manualsort: item.manualsort ? `${item.manualsort}.${String(index + 1).padStart(3, "0")}` : "", content: line }));
+  }
+  return out;
+}
+
+function groupBySection(items) {
+  const grouped = new Map();
+  const source = Array.isArray(items) ? items : [];
+  source.forEach((item) => {
+    const section = key(item.section);
+    if (!section || section === "header" || section === "contact") return;
+    if (!grouped.has(section)) grouped.set(section, []);
+    grouped.get(section).push(item);
+  });
+  return grouped;
+}
+
+function sectionAtoms(title, items, opts = {}) {
+  if (!items.length) return [];
+  const normalized = key(title);
+  const out = [];
+  if (!opts.hideSectionTitle) out.push({ type: "section-title", title, units: 0.5 });
+  sortItems(items).forEach((item) => {
+    const hideTitle = opts.hideAllEntryTitles || (opts.hideEntryTitleWhenSameAsSection && key(item.title) && key(item.title) === normalized);
+    out.push({ type: "entry", item, hideTitle, units: estimateUnits(item, opts.rail) });
+  });
+  return out;
+}
+
+function sectionAtomsOrdered(title, items, opts = {}) {
+  if (!items.length) return [];
+  const normalized = key(title);
+  const out = [];
+  if (!opts.hideSectionTitle) out.push({ type: "section-title", title, units: 0.5 });
+  items.forEach((item) => {
+    const hideTitle = opts.hideAllEntryTitles || (opts.hideEntryTitleWhenSameAsSection && key(item.title) && key(item.title) === normalized);
+    out.push({ type: "entry", item, hideTitle, units: estimateUnits(item, opts.rail) });
+  });
+  return out;
+}
+
+function workAndTechAtoms(workItems, techItems) {
+  const out = [];
+  if (workItems.length || techItems.length) out.push({ type: "section-title", title: "Work Experience", units: 0.5 });
+  sortItems(workItems).forEach((item) => out.push({ type: "entry", item, hideTitle: false, units: estimateUnits(item, false) }));
+  sortItems(techItems).forEach((item) => out.push({ type: "entry", item, hideTitle: false, units: estimateUnits(item, false) }));
+  return out;
+}
+
+function toAtoms(items) {
+  const grouped = groupBySection(items);
+  const mainFirst = [];
+  const mainLater = [];
+  const railSkills = [];
+  const railPage2 = [];
+  const railLater = [];
+
+  mainFirst.push(...sectionAtoms("Core Competencies", grouped.get("core competencies") || [], { hideEntryTitleWhenSameAsSection: true }));
+  mainFirst.push(...workAndTechAtoms(grouped.get("work experience") || [], grouped.get("technical + it") || []));
+  mainLater.push(...sectionAtoms("CV Footer", grouped.get("footer") || [], { hideSectionTitle: true, hideAllEntryTitles: true }));
+
+  railSkills.push(...sectionAtoms("Skills", grouped.get("topline skills") || [], { rail: true }));
+  railPage2.push(...sectionAtoms("Education", grouped.get("education") || [], { rail: true }));
+
+  sortItems(grouped.get("second page rail") || []).forEach((item) => {
+    if (!item.title) return;
+    railLater.push({ type: "section-title", title: item.title, units: 0.5 });
+    railLater.push({ type: "entry", item: { ...item, content: item.content || "" }, hideTitle: true, units: estimateUnits(item, true) });
+  });
+
+  grouped.delete("core competencies");
+  grouped.delete("work experience");
+  grouped.delete("technical + it");
+  grouped.delete("topline skills");
+  grouped.delete("education");
+  grouped.delete("second page rail");
+  grouped.delete("footer");
+
+  [...grouped.keys()].sort().forEach((extraKey) => {
+    const title = extraKey.split(/\s+/).map((w) => w.charAt(0).toUpperCase() + w.slice(1)).join(" ");
+    mainLater.push(...sectionAtoms(title, grouped.get(extraKey) || []));
+  });
+
+  return { mainFirst, mainLater, railSkills, railPage2, railLater };
+}
+
+
+
+function renderEntry(atom) {
+  const item = atom.item;
   const parts = ["<article class=\"entry\">"];
-  const hideTitle = Boolean(options.hideEntryTitle);
-
-  if (item.title && !hideTitle) parts.push(`<h4 class=\"entry-title\">${escapeHtml(item.title)}</h4>`);
-
+  if (item.title && !atom.hideTitle) parts.push(`<h4 class=\"entry-title\">${escapeHtml(item.title)}</h4>`);
   const meta = [item.subtitle, item.location].filter(Boolean).map((x) => escapeHtml(x)).join(" • ");
   if (meta) parts.push(`<div class=\"entry-meta\">${meta}</div>`);
-
-  const dateText = displayDate(item);
-  if (dateText) parts.push(`<div class=\"entry-date\">${escapeHtml(dateText)}</div>`);
-
+  const date = displayDate(item);
+  if (date) parts.push(`<div class=\"entry-date\">${escapeHtml(date)}</div>`);
   if (item.content) parts.push(`<div class=\"entry-content\">${markdownToHtml(item.content)}</div>`);
   parts.push("</article>");
   return parts.join("\n");
 }
 
-function renderSection(title, items, options = {}) {
-  if (!items.length) return "";
-  const normalizedTitle = key(title);
-  const entries = sortItems(items).map((item) => {
-    const hideEntryTitle = options.hideEntryTitleWhenSameAsSection && key(item.title) === normalizedTitle;
-    return renderEntry(item, { hideEntryTitle });
-  }).join("\n");
-
-  const sectionClass = normalizedTitle === "skills" ? "section skills-section" : "section";
-  return `<section class=\"${sectionClass}\"><h3>${escapeHtml(title)}</h3>${entries}</section>`;
-}
-
-function groupBySection(items) {
-  const grouped = new Map();
-  for (const item of items) {
-    const section = key(item.section);
-    if (!section || section === "header" || section === "contact") continue;
-    if (!grouped.has(section)) grouped.set(section, []);
-    grouped.get(section).push(item);
-  }
-  return grouped;
-}
-
-
-function expandSkillsItems(items) {
-  const expanded = [];
-  for (const item of items) {
-    const content = String(item?.content || "");
-    const bulletLines = content
-      .split(/\r?\n/)
-      .map((line) => line.trim())
-      .filter((line) => /^[-*]\s+/.test(line));
-
-    if (bulletLines.length >= 2) {
-      bulletLines.forEach((line, index) => {
-        expanded.push({
-          ...item,
-          title: "",
-          subtitle: "",
-          location: "",
-          start: "",
-          end: "",
-          dispdate: "",
-          manualsort: item.manualsort ? `${item.manualsort}.${String(index + 1).padStart(3, "0")}` : "",
-          content: line
-        });
-      });
-    } else {
-      expanded.push(item);
+function renderColumn(atoms, cls) {
+  const out = [];
+  let open = false;
+  atoms.forEach((atom) => {
+    if (atom.type === "section-title") {
+      if (open) out.push("</section>");
+      out.push(`<section class=\"section ${cls}\"><h3>${escapeHtml(atom.title)}</h3>`);
+      open = true;
+      return;
     }
+    if (!open) {
+      out.push(`<section class=\"section ${cls}\">`);
+      open = true;
+    }
+    out.push(renderEntry(atom));
+  });
+  if (open) out.push("</section>");
+  return out.join("\n");
+}
+
+function renderFooterHtml(techItems, footerItems) {
+  const sections = [];
+
+  const tech = sortItems(techItems || []);
+  if (tech.length) {
+    const techEntries = tech.map((item) => renderEntry({ type: "entry", item, hideTitle: false, units: estimateUnits(item, false) })).join("\n");
+    sections.push(`<section class="section footer-tech"><h3>Technical + IT</h3><div class="tech-grid">${techEntries}</div></section>`);
   }
-  return expanded;
+
+  const footer = sortItems(footerItems || []);
+  if (footer.length) {
+    const footerEntries = footer.map((item) => renderEntry({ type: "entry", item: { ...item, title: "" }, hideTitle: true, units: estimateUnits(item, false) })).join("\n");
+    sections.push(`<section class="section footer-block">${footerEntries}</section>`);
+  }
+
+  return sections.join("\n");
+}
+
+
+function iconClassForContact(text) {
+  const v = String(text || "").toLowerCase();
+  if (v.includes("@")) return "fa-solid fa-envelope";
+  if (v.includes("http") || v.includes("www.")) return "fa-solid fa-globe";
+  if (/[+()\d\s-]{7,}/.test(v)) return "fa-solid fa-phone";
+  return "fa-solid fa-address-card";
 }
 
 function renderContact(contacts) {
   const entries = contacts.filter((item) => String(item?.content || "").trim() !== "");
-  if (!entries.length) return "<section class=\"contact-bar\" id=\"contact\" style=\"display:none\"></section>";
-  return `<section class=\"contact-bar\" id=\"contact\">${entries.map((item) => `<div class=\"contact-item\"><span>${escapeHtml(item.content)}</span></div>`).join("")}</section>`;
+  if (!entries.length) return "";
+  return `<section class=\"contact-bar\">${entries.map((item) => `<div class=\"contact-item\"><i class=\"${iconClassForContact(item.content)}\" aria-hidden=\"true\"></i><span>${escapeHtml(item.content)}</span></div>`).join("")}</section>`;
 }
 
-function renderDocument(cv, cssHref) {
+function splitWorkPageOne(workItems, budget) {
+  const page1WorkItems = [];
+  const page2WorkItems = [];
+  let used = 0;
+  let overflowStarted = false;
+  workItems.forEach((item, idx) => {
+    const units = estimateUnits(item, false);
+    if (!overflowStarted && (idx === 0 || used + units <= budget)) {
+      page1WorkItems.push(item);
+      used += units;
+    } else {
+      overflowStarted = true;
+      page2WorkItems.push(item);
+    }
+  });
+  return { page1WorkItems, page2WorkItems, used };
+}
+
+function composeFiveBlockLayout(items) {
+  const source = Array.isArray(items) ? items : [];
+  const grouped = groupBySection(source);
+
+  const coreAtoms = sectionAtoms("Core Competencies", grouped.get("core competencies") || [], { hideEntryTitleWhenSameAsSection: true });
+  const workItems = grouped.get("work experience") || [];
+  let workPage1Budget = 23;
+  let split = splitWorkPageOne(workItems, workPage1Budget);
+  const leftover = workPage1Budget - split.used;
+  const firstOverflowUnits = split.page2WorkItems.length ? estimateUnits(split.page2WorkItems[0], false) : 0;
+  const barelyMissed = split.page2WorkItems.length > 0 && firstOverflowUnits > leftover && (firstOverflowUnits - leftover) <= 1.2;
+  if (barelyMissed) {
+    workPage1Budget += 1.2;
+    split = splitWorkPageOne(workItems, workPage1Budget);
+  }
+  const compact = barelyMissed;
+
+  if (split.page2WorkItems.length) {
+    const promoteUnits = estimateUnits(split.page2WorkItems[0], false);
+    const promoteThreshold = compact ? 9.5 : 8.5;
+    if (workPage1Budget - split.used + promoteUnits >= promoteThreshold) {
+      split.page1WorkItems.push(split.page2WorkItems.shift());
+    }
+  }
+
+  const mainPage1Atoms = coreAtoms.concat(sectionAtomsOrdered("Work Experience", split.page1WorkItems));
+  const mainPage2Atoms = [];
+  if (split.page2WorkItems.length) {
+    mainPage2Atoms.push(...sectionAtomsOrdered("Work Experience (Cont.)", split.page2WorkItems));
+  }
+
+  const footerTechItems = sortItems(grouped.get("technical + it") || []);
+  const footerItems = sortItems(grouped.get("footer") || []);
+
+  grouped.delete("core competencies");
+  grouped.delete("work experience");
+  grouped.delete("technical + it");
+  grouped.delete("footer");
+
+  [...grouped.keys()].sort().forEach((extraKey) => {
+    if (["topline skills", "education", "second page rail", "footer"].includes(extraKey)) return;
+    const title = extraKey.split(/\s+/).map((w) => w.charAt(0).toUpperCase() + w.slice(1)).join(" ");
+    mainPage2Atoms.push(...sectionAtoms(title, grouped.get(extraKey) || []));
+  });
+
+  const railFirstPageAtoms = [];
+  railFirstPageAtoms.push(...sectionAtoms("Skills", grouped.get("topline skills") || [], { rail: true }));
+
+  const railSecondPageAtoms = [];
+  railSecondPageAtoms.push(...sectionAtoms("Education", grouped.get("education") || [], { rail: true }));
+  sortItems(grouped.get("second page rail") || []).forEach((item) => {
+    if (!item.title) return;
+    railSecondPageAtoms.push({ type: "section-title", title: item.title, units: 0.5 });
+    railSecondPageAtoms.push({ type: "entry", item: { ...item, content: item.content || "" }, hideTitle: true, units: estimateUnits(item, true) });
+  });
+
+  return { mainPage1Atoms, mainPage2Atoms, railPage1Atoms: railFirstPageAtoms, railPage2Atoms: railSecondPageAtoms, footerTechItems, footerItems, compact };
+}
+
+function renderPdfDocumentHtml(cv, cssHref) {
   const items = Array.isArray(cv.items) ? cv.items : [];
   const header = items.find((item) => key(item.section) === "header") || {};
   const contacts = items.filter((item) => key(item.section) === "contact");
-  const grouped = groupBySection(items);
+  const blocks = composeFiveBlockLayout(items);
 
-  const mainConfig = [
-    { key: "core competencies", title: "Core Competencies", hideTitle: true },
-    { key: "work experience", title: "Work Experience", hideTitle: false },
-    { key: "technical + it", title: "Technical + IT", hideTitle: false }
+  const headerHtml = `<header class="header"><h1>${escapeHtml(header?.title || "CV")}</h1><h2>${escapeHtml(header?.subtitle || "")}</h2><div class="header-summary">${markdownToHtml(header?.content || "")}</div></header>${renderContact(contacts)}`;
+
+  const fullContainer = `<div class="full-container"><div class="header-container">${headerHtml}</div><div class="rail-page-1">${renderColumn(blocks.railPage1Atoms, "col-rail")}</div><div class="main-content-1">${renderColumn(blocks.mainPage1Atoms, "col-main")}</div><div class="rail-page-2">${renderColumn(blocks.railPage2Atoms, "col-rail")}</div><div class="main-content-2">${renderColumn(blocks.mainPage2Atoms, "col-main")}</div><div class="footer">${renderFooterHtml(blocks.footerTechItems, blocks.footerItems)}</div></div>`;
+
+  return `<!doctype html><html lang="en"><head><meta charset="UTF-8" /><meta name="viewport" content="width=device-width, initial-scale=1.0" /><title>CV Print</title><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" /><link rel="stylesheet" href="${cssHref}" /></head><body><main class="cv-print${blocks.compact ? " compact" : ""}" id="cv-print-root">${fullContainer}</main></body></html>`;
+}
+
+function summarizeAtoms(atoms) {
+  const summary = { sections: 0, entries: 0, sectionTitles: [] };
+  (atoms || []).forEach((atom) => {
+    if (atom.type === "section-title") {
+      summary.sections += 1;
+      summary.sectionTitles.push(atom.title);
+      return;
+    }
+    if (atom.type === "entry") summary.entries += 1;
+  });
+  return summary;
+}
+
+function buildPdfRecap(slug, cv, blocks, options = {}) {
+  const header = (Array.isArray(cv.items) ? cv.items : []).find((item) => key(item.section) === "header") || {};
+  const page1Main = summarizeAtoms(blocks.mainPage1Atoms);
+  const page2Main = summarizeAtoms(blocks.mainPage2Atoms);
+  const page1Rail = summarizeAtoms(blocks.railPage1Atoms);
+  const page2Rail = summarizeAtoms(blocks.railPage2Atoms);
+
+  const lines = [
+    `# PDF Recap: ${slug}`,
+    "",
+    `- Generated: ${new Date().toISOString()}`,
+    `- CV title: ${String(header.title || "Untitled CV")}`,
+    `- CV subtitle: ${String(header.subtitle || "").trim() || "n/a"}`,
+    `- Layout mode: ${blocks.compact ? "compact" : "standard"}`,
+    `- HTTP mode: ${options.useHttpMode ? "enabled" : "disabled"}`,
+    `- Legacy press-ready mode: ${options.useLegacyPressReady ? "enabled" : "disabled"}`,
+    "",
+    "## Page content totals",
+    "",
+    `- Page 1 main column: ${page1Main.sections} sections, ${page1Main.entries} entries`,
+    `- Page 1 rail column: ${page1Rail.sections} sections, ${page1Rail.entries} entries`,
+    `- Page 2 main column: ${page2Main.sections} sections, ${page2Main.entries} entries`,
+    `- Page 2 rail column: ${page2Rail.sections} sections, ${page2Rail.entries} entries`,
+    `- Footer technical items: ${(blocks.footerTechItems || []).length}`,
+    `- Footer items: ${(blocks.footerItems || []).length}`,
+    "",
+    "## Section titles by column",
+    "",
+    `- Page 1 main: ${page1Main.sectionTitles.join(", ") || "none"}`,
+    `- Page 1 rail: ${page1Rail.sectionTitles.join(", ") || "none"}`,
+    `- Page 2 main: ${page2Main.sectionTitles.join(", ") || "none"}`,
+    `- Page 2 rail: ${page2Rail.sectionTitles.join(", ") || "none"}`,
+    "",
   ];
 
-  const skillsItems = expandSkillsItems(grouped.get("topline skills") || []);
-  const educationItems = grouped.get("education") || [];
-
-  const mainSections = [];
-  for (const cfg of mainConfig) {
-    const sectionItems = grouped.get(cfg.key) || [];
-    grouped.delete(cfg.key);
-    mainSections.push(renderSection(cfg.title, sectionItems, { hideEntryTitleWhenSameAsSection: cfg.hideTitle }));
-  }
-
-  grouped.delete("topline skills");
-  grouped.delete("education");
-
-  const secondRail = grouped.get("second page rail") || [];
-  grouped.delete("second page rail");
-  const secondRailSections = [];
-  for (const item of sortItems(secondRail)) {
-    if (!item.title) continue;
-    secondRailSections.push(`<section class="section"><h3>${escapeHtml(item.title)}</h3><div class="entry-content">${markdownToHtml(item.content || "")}</div></section>`);
-  }
-
-  const extraKeys = [...grouped.keys()].sort();
-  for (const extraKey of extraKeys) {
-    const title = extraKey.replace(/\b\w/g, (c) => c.toUpperCase());
-    mainSections.push(renderSection(title, grouped.get(extraKey) || []));
-  }
-
-  const railSections = [];
-  railSections.push(renderSection("Skills", skillsItems));
-  railSections.push(renderSection("Education", educationItems));
-  railSections.push(secondRailSections.join("\n"));
-
-  return `<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>CV Print</title>
-    <link rel="stylesheet" href="${cssHref}" />
-  </head>
-  <body>
-    <main class="cv-print" id="cv-print-root">
-      <header class="header" id="header">
-        <h1>${escapeHtml(header?.title || "CV")}</h1>
-        <h2>${escapeHtml(header?.subtitle || "")}</h2>
-        <div class="header-summary">${markdownToHtml(header?.content || "")}</div>
-      </header>
-      ${renderContact(contacts)}
-      <section class="content">
-        <div class="main-col" id="main-col">${mainSections.join("\n")}</div>
-        <aside class="rail-col" id="rail-col">${railSections.join("\n")}</aside>
-      </section>
-    </main>
-    <script>
-      (function applyRailEducationBreakIfSkillsFit() {
-        const root = document.getElementById("cv-print-root");
-        const railHost = document.getElementById("rail-col");
-        if (!root || !railHost) return;
-
-        const sections = [...railHost.querySelectorAll(':scope > .section')];
-        const skillsSection = sections.find((section) => section.querySelector('h3')?.textContent?.trim().toLowerCase() === 'skills');
-        const educationSection = sections.find((section) => section.querySelector('h3')?.textContent?.trim().toLowerCase() === 'education');
-        if (!skillsSection || !educationSection) return;
-
-        educationSection.classList.remove('rail-page-break');
-
-        const mmProbe = document.createElement("div");
-        mmProbe.style.width = "1mm";
-        mmProbe.style.position = "absolute";
-        mmProbe.style.visibility = "hidden";
-        document.body.appendChild(mmProbe);
-        const pxPerMm = mmProbe.getBoundingClientRect().width || 3.7795;
-        mmProbe.remove();
-
-        const pageHeightPx = 297 * pxPerMm;
-        const pageMarginPx = 12 * pxPerMm;
-        const firstPageBottom = root.getBoundingClientRect().top + pageHeightPx - pageMarginPx;
-        const railTop = railHost.getBoundingClientRect().top;
-        const availableRailHeightOnFirstPage = firstPageBottom - railTop;
-        if (availableRailHeightOnFirstPage <= 0) return;
-
-        const skillsHeight = skillsSection.getBoundingClientRect().height;
-        if (skillsHeight <= availableRailHeightOnFirstPage) {
-          educationSection.classList.add('rail-page-break');
-        }
-      })();
-    </script>
-  </body>
-</html>`;
+  return lines.join("\n");
 }
+
 
 function buildPdfForSlug(slug, cssHref) {
   const jsonPath = path.join("data", "cv", `${slug}.json`);
   const outputPath = path.join("dist", `${slug}.pdf`);
+  const recapPath = path.join("dist", `${slug}.pdf-recap.md`);
   const tmpPath = path.join(".tmp", `cv-print-${slug}.html`);
-
   const cv = JSON.parse(fs.readFileSync(jsonPath, "utf8"));
+  const blocks = composeFiveBlockLayout(Array.isArray(cv.items) ? cv.items : []);
   fs.mkdirSync(path.dirname(tmpPath), { recursive: true });
-  fs.writeFileSync(tmpPath, renderDocument(cv, cssHref), "utf8");
-
-  execFileSync("npx", ["vivliostyle", "build", tmpPath, "-o", outputPath], { stdio: "inherit" });
+  fs.writeFileSync(tmpPath, renderPdfDocumentHtml(cv, cssHref), "utf8");
+  // Keep local-file rendering as default so existing layout styling remains stable.
+  // For HTTP-mode debugging, set CV_PDF_USE_HTTP=1.
+  const useHttpMode = process.env.CV_PDF_USE_HTTP === "1";
+  // Keep text selectable/searchable by default; opt into legacy PDF/X if needed.
+  const useLegacyPressReady = process.env.CV_PDF_LEGACY_PRESS_READY === "1";
+  const skipPdfBuild = process.env.CV_PDF_RECAP_ONLY === "1";
+  fs.writeFileSync(recapPath, buildPdfRecap(slug, cv, blocks, { useHttpMode, useLegacyPressReady }), "utf8");
+  console.log(`[build-cv-pdf] Wrote recap: ${recapPath}`);
+  if (skipPdfBuild) {
+    console.log(`[build-cv-pdf] CV_PDF_RECAP_ONLY=1 set; skipping PDF build for ${slug}`);
+    return;
+  }
+  const cmd = ["vivliostyle", "build", tmpPath, "-o", outputPath];
+  if (useHttpMode) {
+    cmd.push("--http");
+  }
+  if (useLegacyPressReady) {
+    cmd.push("--press-ready");
+  }
+  execFileSync("npx", cmd, { stdio: "inherit" });
 }
 
 function main() {
   fs.mkdirSync("dist", { recursive: true });
   fs.mkdirSync(".tmp", { recursive: true });
-
   const cssHref = pathToFileURL(path.resolve("cv-print.css")).href;
-
   try {
-    const slugs = fs
-      .readdirSync(path.join("data", "cv"))
-      .filter((file) => file.endsWith(".json"))
-      .map((file) => file.replace(/\.json$/, ""))
-      .sort();
-
+    const slugs = fs.readdirSync(path.join("data", "cv")).filter((file) => file.endsWith(".json")).map((file) => file.replace(/\.json$/, "")).sort();
     if (!slugs.length) throw new Error("No CV JSON files found in data/cv");
-
-    for (const slug of slugs) {
+    slugs.forEach((slug) => {
       console.log(`[build-cv-pdf] Building PDF for slug: ${slug}`);
       buildPdfForSlug(slug, cssHref);
-    }
+    });
   } finally {
     fs.rmSync(".tmp", { recursive: true, force: true });
   }

--- a/scripts/run-cv-ai-feedback.js
+++ b/scripts/run-cv-ai-feedback.js
@@ -1,0 +1,539 @@
+import fs from "fs";
+
+const AIRTABLE_BASE_ID = process.env.AIRTABLE_BASE_ID || "YOUR_AIRTABLE_BASE_ID";
+const CVS_TABLE_NAME = process.env.CVS_TABLE_NAME || "CVs";
+const CVS_TABLE_ID = process.env.CVS_TABLE_ID || "tbl4GZ7jQcccKPyJu";
+const CV_ITEMS_TABLE_NAME = process.env.CV_ITEMS_TABLE_NAME || "CV Items";
+const CV_ITEMS_TABLE_ID = process.env.CV_ITEMS_TABLE_ID || "tblTNlBDhAjF32Sna";
+
+const AIRTABLE_PAT = process.env.AIRTABLE_PAT;
+const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
+const ISSUE_TITLE = process.env.ISSUE_TITLE || "";
+const ISSUE_BODY = process.env.ISSUE_BODY || "";
+const GITHUB_OUTPUT = process.env.GITHUB_OUTPUT;
+
+function logDebug(message, data) {
+  if (data === undefined) {
+    console.log(`[cv-ai-feedback] ${message}`);
+    return;
+  }
+  console.log(`[cv-ai-feedback] ${message}: ${JSON.stringify(data)}`);
+}
+
+function setOutput(name, value) {
+  if (!GITHUB_OUTPUT) return;
+  fs.appendFileSync(GITHUB_OUTPUT, `${name}=${String(value)}\n`, "utf8");
+}
+
+function parseRecordId(title, body) {
+  const titleTokens = String(title).trim().split(/\s+/).filter(Boolean);
+  if (String(titleTokens[0] || "").toUpperCase() === "CV_UPDATE" && titleTokens[1]?.startsWith("rec")) {
+    return titleTokens[1];
+  }
+
+  const bodyMatch = String(body).match(/^recordid\s+(rec[\w]+)/im);
+  if (bodyMatch?.[1]) return bodyMatch[1];
+  return "";
+}
+
+function valueOrNull(value) {
+  return value === undefined ? null : value;
+}
+
+
+function normalizeRichTextFieldValue(value) {
+  if (value === undefined || value === null) return "";
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+
+  if (Array.isArray(value)) {
+    return value.map((part) => normalizeRichTextFieldValue(part)).join("").trim();
+  }
+
+  if (typeof value === "object") {
+    const directKeys = ["text", "plain_text", "value", "content", "name"];
+    for (const key of directKeys) {
+      if (typeof value[key] === "string") return value[key];
+    }
+
+    const nestedKeys = ["text", "value", "content", "children", "richText", "rich_text"];
+    const nestedParts = [];
+    for (const key of nestedKeys) {
+      if (value[key] !== undefined && value[key] !== null) {
+        const normalized = normalizeRichTextFieldValue(value[key]);
+        if (normalized) nestedParts.push(normalized);
+      }
+    }
+    if (nestedParts.length) return nestedParts.join(" ").trim();
+
+    const fallback = [];
+    for (const v of Object.values(value)) {
+      const normalized = normalizeRichTextFieldValue(v);
+      if (normalized) fallback.push(normalized);
+    }
+    return fallback.join(" ").trim();
+  }
+
+  return String(value);
+}
+
+
+function getCvFooterValue(fields) {
+  const direct = [fields["CV_Footer"], fields["CV Footer"]];
+  for (const candidate of direct) {
+    const normalized = normalizeRichTextFieldValue(candidate);
+    if (normalized) return normalized;
+  }
+
+  const normalizeFieldName = (name) => String(name || "").toLowerCase().replace(/[^a-z0-9]/g, "");
+  const target = "cvfooter";
+  for (const [fieldName, fieldValue] of Object.entries(fields || {})) {
+    if (normalizeFieldName(fieldName) !== target) continue;
+    const normalized = normalizeRichTextFieldValue(fieldValue);
+    if (normalized) return normalized;
+  }
+
+  return "";
+}
+
+
+function escapeFormulaString(value) {
+  return String(value).replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+async function airtableGetJson(url, contextLabel) {
+  logDebug(`Requesting Airtable (${contextLabel})`, url.replace(AIRTABLE_PAT || "", "***"));
+  const res = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${AIRTABLE_PAT}`,
+      "Content-Type": "application/json"
+    }
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Airtable request failed (${res.status}) during ${contextLabel}: ${text}`);
+  }
+
+  return res.json();
+}
+
+async function airtablePatchJson(url, body, contextLabel) {
+  logDebug(`Patching Airtable (${contextLabel})`, url.replace(AIRTABLE_PAT || "", "***"));
+  const res = await fetch(url, {
+    method: "PATCH",
+    headers: {
+      Authorization: `Bearer ${AIRTABLE_PAT}`,
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify(body)
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Airtable patch failed (${res.status}) during ${contextLabel}: ${text}`);
+  }
+
+  return res.json();
+}
+
+async function fetchCvRecord(recordId) {
+  const tableRef = CVS_TABLE_ID || CVS_TABLE_NAME;
+  const url = `https://api.airtable.com/v0/${encodeURIComponent(AIRTABLE_BASE_ID)}/${encodeURIComponent(tableRef)}/${encodeURIComponent(recordId)}`;
+  return airtableGetJson(url, "fetchCvRecord");
+}
+
+async function fetchCvItems(recordId, linkedItemIds = []) {
+  const out = [];
+  let offset = "";
+
+  const useLinkedIds = Array.isArray(linkedItemIds) && linkedItemIds.length > 0;
+  const idFormula = useLinkedIds
+    ? `OR(${linkedItemIds.map((id) => `RECORD_ID()="${escapeFormulaString(id)}"`).join(",")})`
+    : `FIND("${escapeFormulaString(recordId)}", ARRAYJOIN({Parent-CV}))`;
+
+  const filterByFormula = `AND({Publish}=TRUE(), ${idFormula})`;
+
+  do {
+    const params = new URLSearchParams({
+      filterByFormula,
+      pageSize: "100",
+      "sort[0][field]": "Manual sort",
+      "sort[0][direction]": "asc"
+    });
+    if (offset) params.set("offset", offset);
+
+    const tableRef = CV_ITEMS_TABLE_ID || CV_ITEMS_TABLE_NAME;
+    const url = `https://api.airtable.com/v0/${encodeURIComponent(AIRTABLE_BASE_ID)}/${encodeURIComponent(tableRef)}?${params.toString()}`;
+    const data = await airtableGetJson(url, "fetchCvItems");
+
+    out.push(...(data.records || []));
+    offset = data.offset || "";
+  } while (offset);
+
+  return out;
+}
+
+function mapItem(record) {
+  const f = record.fields || {};
+  return {
+    recordId: record.id,
+    title: valueOrNull(f["Headline"]),
+    subtitle: valueOrNull(f["Organization / Subtitle"]),
+    location: valueOrNull(f["Location"]),
+    start: valueOrNull(f["Start Date"]),
+    end: valueOrNull(f["End Date"]),
+    dispdate: valueOrNull(f["Display Date"]),
+    content: valueOrNull(f["Content"]),
+    section: valueOrNull(f["Section"]),
+    manualsort: valueOrNull(f["Manual sort"])
+  };
+}
+
+function compareManualSort(a, b) {
+  const aKey = String(a.manualsort || "").trim();
+  const bKey = String(b.manualsort || "").trim();
+  if (aKey && bKey) return aKey.localeCompare(bKey, undefined, { numeric: true, sensitivity: "base" });
+  if (aKey) return -1;
+  if (bKey) return 1;
+  return 0;
+}
+
+function buildCvPayload(cvRecord, cvItemRecords) {
+  const fields = cvRecord.fields || {};
+  const items = [];
+  items.push({
+    title: valueOrNull(fields["Person Name"]),
+    subtitle: valueOrNull(fields["CV Subtitle"]),
+    content: valueOrNull(fields["Intro Summary"]),
+    section: "header"
+  });
+
+  const pushContact = (title, value) => {
+    if (value !== undefined && value !== null && String(value).trim() !== "") {
+      items.push({ title, content: value, section: "contact" });
+    }
+  };
+
+  pushContact("Email", fields["Contact: Email"]);
+  pushContact("Website", fields["Contact: Personal Website"]);
+  pushContact("Phone", fields["Contact: Phone Number"]);
+
+  if (fields["Core Competencies"] !== undefined && fields["Core Competencies"] !== null && String(fields["Core Competencies"]).trim() !== "") {
+    items.push({ title: "Core Competencies", content: fields["Core Competencies"], section: "core competencies" });
+  }
+
+  const cvFooter = getCvFooterValue(fields);
+  if (String(cvFooter).trim() !== "") {
+    items.push({ title: "CV Footer", content: cvFooter, section: "footer" });
+  }
+
+  cvItemRecords
+    .map(mapItem)
+    .sort(compareManualSort)
+    .forEach((item) => items.push(item));
+
+  return { slug: String(fields["Slug"] || ""), status: String(fields["Status"] || ""), items };
+}
+
+
+
+function cvItemToStructuredLine(item, index) {
+  const title = item?.title ? `title="${item.title}"` : "title=";
+  const subtitle = item?.subtitle ? ` subtitle="${item.subtitle}"` : "";
+  const location = item?.location ? ` location="${item.location}"` : "";
+  const dispdate = item?.dispdate ? ` date="${item.dispdate}"` : "";
+  const section = item?.section ? ` section="${item.section}"` : "";
+  const content = String(item?.content || "").trim();
+  const parts = [`- [${index + 1}] ${title}${subtitle}${location}${dispdate}${section}`];
+  if (content) {
+    const oneLineContent = content
+      .split("\n")
+      .map((line) => line.replace(/\r/g, "").trim())
+      .filter(Boolean)
+      .join(" ");
+    parts.push(`  content: ${oneLineContent}`);
+  }
+  return parts.join("\n");
+}
+function cvItemsToStructuredText(cvJson) {
+  const items = Array.isArray(cvJson?.items) ? cvJson.items : [];
+  const sectionMap = new Map();
+
+  for (const item of items) {
+    const section = String(item?.section || "").trim() || "(unsectioned)";
+    if (!sectionMap.has(section)) sectionMap.set(section, []);
+    sectionMap.get(section).push(item);
+  }
+
+  const parts = [];
+  parts.push(`Slug: ${cvJson?.slug || ""}`);
+
+  for (const [section, entries] of sectionMap.entries()) {
+    parts.push(`\n## ${section}`);
+    entries.forEach((entry, index) => {
+      parts.push(cvItemToStructuredLine(entry, index));
+    });
+  }
+
+  return parts.join("\n");
+}
+
+async function generateOverallAiFeedback(cvJson) {
+  const cvText = cvItemsToStructuredText(cvJson);
+  const prompt = [
+    "You are an expert CV reviewer.",
+    "Assess this CV for clarity, impact, structure, credibility, and writing quality.",
+    "Explicitly check for misspellings, typos, grammatical issues, and stylistic inconsistencies.",
+    "Return concise feedback in plain text with:",
+    "1) Overall assessment (2-3 sentences)",
+    "2) Top strengths (3 bullets)",
+    "3) Top improvements (3 bullets)",
+    "Keep output under 220 words."
+  ].join("\n");
+
+  const response = await fetch("https://api.openai.com/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${OPENAI_API_KEY}`,
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      model: "gpt-5.4",
+      messages: [
+        { role: "system", content: "You provide actionable CV quality feedback." },
+        { role: "user", content: `${prompt}\n\nCV DATA:\n${cvText}` }
+      ],
+      temperature: 0.3
+    })
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`OpenAI API failed (${response.status}): ${text}`);
+  }
+
+  const data = await response.json();
+  const feedback = data?.choices?.[0]?.message?.content?.trim();
+  if (!feedback) throw new Error("OpenAI API returned empty feedback.");
+  return feedback;
+}
+
+
+
+async function generateItemAiFeedback(cvJson, targetItem, targetIndex) {
+  const cvText = cvItemsToStructuredText(cvJson);
+  const targetText = cvItemToStructuredLine(targetItem, targetIndex);
+  const prompt = [
+    "You are an expert CV editor. You are reviewing one specific CV item with the full CV as context.",
+    "Goal: improve this single item while avoiding duplication with other entries.",
+    "Prioritize recency and impact: recent work experience should carry more weight than older roles.",
+    "Give specific rewrite guidance for phrasing, concision, and measurable outcomes where possible.",
+    "Return plain text under 160 words with:",
+    "1) Quick assessment (1-2 sentences)",
+    "2) Suggested edit (2-4 bullets)",
+    "3) Duplicate/redundancy warnings (0-2 bullets, only if needed)"
+  ].join("\n");
+
+  const response = await fetch("https://api.openai.com/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${OPENAI_API_KEY}`,
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      model: "gpt-5.4",
+      messages: [
+        { role: "system", content: "You provide actionable, item-level CV feedback." },
+        { role: "user", content: `${prompt}\n\nTARGET ITEM:\n${targetText}\n\nFULL CV CONTEXT:\n${cvText}` }
+      ],
+      temperature: 0.3
+    })
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`OpenAI API failed for item feedback (${response.status}): ${text}`);
+  }
+
+  const data = await response.json();
+  const feedback = data?.choices?.[0]?.message?.content?.trim();
+  if (!feedback) throw new Error("OpenAI API returned empty item feedback.");
+  return feedback;
+}
+
+async function writeItemAiFeedback(recordId, feedback) {
+  const tableRef = CV_ITEMS_TABLE_ID || CV_ITEMS_TABLE_NAME;
+  const url = `https://api.airtable.com/v0/${encodeURIComponent(AIRTABLE_BASE_ID)}/${encodeURIComponent(tableRef)}/${encodeURIComponent(recordId)}`;
+  await airtablePatchJson(url, { fields: { "AI Feedback": feedback } }, "writeItemAiFeedback");
+}
+
+function isFeedbackEligibleItem(item) {
+  const hasContent = String(item?.content || "").trim() !== "";
+  const hasTitle = String(item?.title || "").trim() !== "";
+  const sectionKey = String(item?.section || "").trim().toLowerCase();
+  if (!hasContent && !hasTitle) return false;
+  if (sectionKey === "header" || sectionKey === "contact" || sectionKey === "education" || sectionKey === "second page rail") return false;
+  return true;
+}
+
+
+function getCvFieldTarget(cvPayload, key) {
+  const items = Array.isArray(cvPayload?.items) ? cvPayload.items : [];
+  if (key === "intro") {
+    const header = items.find((item) => String(item?.section || "").toLowerCase() === "header");
+    if (!header || String(header?.content || "").trim() === "") return null;
+    return {
+      fieldName: "AI Feedback Intro",
+      label: "CV Intro",
+      title: header?.title || "",
+      content: header?.content || "",
+      section: "header"
+    };
+  }
+
+  if (key === "core") {
+    const core = items.find((item) => String(item?.section || "").toLowerCase() === "core competencies");
+    if (!core || String(core?.content || "").trim() === "") return null;
+    return {
+      fieldName: "AI Feedback Core Competencies",
+      label: "Core Competencies",
+      title: core?.title || "Core Competencies",
+      content: core?.content || "",
+      section: "core competencies"
+    };
+  }
+
+  if (key === "footer") {
+    const footer = items.find((item) => String(item?.section || "").toLowerCase() === "footer");
+    if (!footer || String(footer?.content || "").trim() === "") return null;
+    return {
+      fieldName: "AI Feedback Footer",
+      label: "CV Footer",
+      title: footer?.title || "CV Footer",
+      content: footer?.content || "",
+      section: "footer"
+    };
+  }
+
+  return null;
+}
+
+function cvFieldTargetToStructuredText(target) {
+  const title = target?.title ? `title="${target.title}"` : "title=";
+  const section = target?.section ? ` section="${target.section}"` : "";
+  const content = String(target?.content || "").trim();
+  const oneLineContent = content
+    .split("\n")
+    .map((line) => line.replace(/\r/g, "").trim())
+    .filter(Boolean)
+    .join(" ");
+  return [`- ${title}${section}`, `  content: ${oneLineContent}`].join("\n");
+}
+
+async function generateCvFieldAiFeedback(cvJson, target) {
+  const cvText = cvItemsToStructuredText(cvJson);
+  const targetText = cvFieldTargetToStructuredText(target);
+  const prompt = [
+    "You are an expert CV editor. Review this specific CV-level block with full CV context.",
+    "Goal: improve this block for clarity, specificity, and impact while avoiding duplication with other CV sections.",
+    "Prioritize recency and relevance where applicable.",
+    "Check for typos, grammar issues, and style inconsistencies.",
+    "Return plain text under 150 words with:",
+    "1) Quick assessment (1-2 sentences)",
+    "2) Suggested rewrite improvements (2-4 bullets)",
+    "3) Duplicate/redundancy warnings (0-2 bullets, only if needed)"
+  ].join("\n");
+
+  const response = await fetch("https://api.openai.com/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${OPENAI_API_KEY}`,
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      model: "gpt-5.4",
+      messages: [
+        { role: "system", content: "You provide actionable CV block-level feedback." },
+        { role: "user", content: `${prompt}\n\nTARGET BLOCK (${target.label}):\n${targetText}\n\nFULL CV CONTEXT:\n${cvText}` }
+      ],
+      temperature: 0.3
+    })
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`OpenAI API failed for CV field feedback (${response.status}): ${text}`);
+  }
+
+  const data = await response.json();
+  const feedback = data?.choices?.[0]?.message?.content?.trim();
+  if (!feedback) throw new Error("OpenAI API returned empty CV field feedback.");
+  return feedback;
+}
+
+async function writeCvFieldFeedback(recordId, fieldName, feedback) {
+  const tableRef = CVS_TABLE_ID || CVS_TABLE_NAME;
+  const url = `https://api.airtable.com/v0/${encodeURIComponent(AIRTABLE_BASE_ID)}/${encodeURIComponent(tableRef)}/${encodeURIComponent(recordId)}`;
+  await airtablePatchJson(url, { fields: { [fieldName]: feedback } }, "writeCvFieldFeedback");
+}
+async function writeOverallAiFeedbackToCv(recordId, feedback) {
+  const tableRef = CVS_TABLE_ID || CVS_TABLE_NAME;
+  const url = `https://api.airtable.com/v0/${encodeURIComponent(AIRTABLE_BASE_ID)}/${encodeURIComponent(tableRef)}/${encodeURIComponent(recordId)}`;
+  await airtablePatchJson(url, { fields: { "Overall AI Feedback": feedback } }, "writeOverallAiFeedbackToCv");
+}
+
+async function main() {
+  if (!AIRTABLE_PAT) throw new Error("Missing AIRTABLE_PAT secret.");
+  if (!OPENAI_API_KEY) throw new Error("Missing OPENAI_API_KEY secret.");
+  if (!AIRTABLE_BASE_ID || AIRTABLE_BASE_ID === "YOUR_AIRTABLE_BASE_ID") {
+    throw new Error("AIRTABLE_BASE_ID is not configured.");
+  }
+
+  const recordId = parseRecordId(ISSUE_TITLE, ISSUE_BODY);
+  if (!recordId) throw new Error("No trigger record id found in issue title/body.");
+
+  const cvRecord = await fetchCvRecord(recordId);
+  const linkedCvItems = Array.isArray(cvRecord?.fields?.["CV Items"]) ? cvRecord.fields["CV Items"] : [];
+  const cvItems = await fetchCvItems(recordId, linkedCvItems);
+  const cvPayload = buildCvPayload(cvRecord, cvItems);
+  const feedback = await generateOverallAiFeedback(cvPayload);
+  await writeOverallAiFeedbackToCv(recordId, feedback);
+  logDebug("Wrote Overall AI Feedback", { recordId, chars: feedback.length });
+
+  const cvFieldTargets = [
+    getCvFieldTarget(cvPayload, "intro"),
+    getCvFieldTarget(cvPayload, "core"),
+    getCvFieldTarget(cvPayload, "footer")
+  ].filter(Boolean);
+
+  for (const target of cvFieldTargets) {
+    const fieldFeedback = await generateCvFieldAiFeedback(cvPayload, target);
+    await writeCvFieldFeedback(recordId, target.fieldName, fieldFeedback);
+    logDebug("Wrote CV field AI Feedback", { recordId, fieldName: target.fieldName, chars: fieldFeedback.length });
+  }
+
+  const mappedItems = cvItems.map(mapItem).sort(compareManualSort);
+  const feedbackTargets = mappedItems
+    .map((item, index) => ({ item, index }))
+    .filter(({ item }) => isFeedbackEligibleItem(item));
+
+  for (const target of feedbackTargets) {
+    if (!target.item.recordId) continue;
+    const itemFeedback = await generateItemAiFeedback(cvPayload, target.item, target.index);
+    await writeItemAiFeedback(target.item.recordId, itemFeedback);
+    logDebug("Wrote AI Feedback for CV Item", { itemRecordId: target.item.recordId, chars: itemFeedback.length });
+  }
+
+  setOutput("record_id", recordId);
+  setOutput("ai_feedback_written", "true");
+  setOutput("ai_cv_field_feedback_written", String(cvFieldTargets.length));
+  setOutput("ai_item_feedback_written", String(feedbackTargets.length));
+}
+
+main().catch((err) => {
+  const message = err?.message || String(err);
+  setOutput("error", message);
+  console.error(message);
+  process.exit(1);
+});

--- a/vivliostyle.config.js
+++ b/vivliostyle.config.js
@@ -4,6 +4,8 @@ export default {
   output: ["dist/coleman-davis.pdf"],
   workspaceDir: ".",
   size: "A4",
-  pressReady: true,
+  // Keep searchable/selectable text by default.
+  // For legacy PDF/X output, use: CV_PDF_LEGACY_PRESS_READY=1 npm run pdf:build
+  pressReady: false,
   timeout: 120000
 };


### PR DESCRIPTION
### Motivation

- Provide an issue-triggered AI feedback automation that can generate and write CV feedback back to Airtable. 
- Offer an embeddable, non-iframe CV widget and a feedback review UI for easier inspection of AI feedback and CV presentation. 
- Improve the JSON export and rendering pipeline to support richer field normalization and a more predictable paginated PDF layout. 
- Make the PDF builder produce a human-readable recap and add flags to control HTTP/press-ready behavior for robust CI/local runs.

### Description

- Added a new GitHub Actions workflow `/.github/workflows/cv-ai-feedback.yml` to run AI feedback (issue/manual triggers) and post success/failure comments. 
- Introduced `scripts/run-cv-ai-feedback.js` and wired `npm run ai:feedback` in `package.json` to call the OpenAI API and write `Overall AI Feedback` / field-level / item-level feedback into Airtable. 
- Implemented an embeddable widget and docs via `cv-embed.js`, `cv-embed.html`, and a viewer page `cv/index.html`, plus a feedback UI `cv-feedback.html` for side-by-side item/overall feedback review. 
- Refactored render and PDF build flows: `cv-render.js` was reworked to atomize entries and provide `renderPaginatedCv` and `renderStandardCv`, and `scripts/build-cv-pdf.js` was rewritten to compose five-block layouts, paginate by estimated units, emit a recap `.pdf-recap.md`, and expose env flags `CV_PDF_RECAP_ONLY`, `CV_PDF_USE_HTTP`, and `CV_PDF_LEGACY_PRESS_READY`. 
- Improved JSON generation in `scripts/build-cv-json.js` with robust rich-text normalization via `normalizeRichTextFieldValue`, footer extraction via `getCvFooterValue`, inclusion of `feedback` fields in the JSON output, and preservation of `recordId` and `aiFeedback` on items. 
- Updated assets and pages: added `cv-print.css`, updated `cv-print.html` and `cv.html` to use the new renderer/fallbacks and to expose `dist/<slug>.pdf` links; added `README.md` documenting flows; set `pressReady: false` in `vivliostyle.config.js` for searchable PDFs. 
- Minor CI/workflow tweak in `.github/workflows/build-cv-pdf.yml` to use `git pull --no-rebase -X ours origin "$branch"` for push retries when committing generated JSON/PDF files.

### Testing

- Executed the PDF build via `npm run pdf:build` (invoked `node scripts/build-cv-pdf.js`), which produced the recap file `dist/coleman-davis.pdf-recap.md` and completed cleanup of `.tmp` successfully. 
- Generated the temporary print HTML used for Vivliostyle and exercised the recap-only path using `CV_PDF_RECAP_ONLY` to validate layout logic without invoking browser downloads. 
- No automated AI feedback runs were executed in this rollout (the workflow and `npm run ai:feedback` command were added but not run end-to-end in CI as part of this change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0161e14888322af1ced8e59c5c579)